### PR TITLE
Introduce GoReleaser for building releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-# Test binary, built with `go test -c`
-*.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
+dist/
 *.out
+*.test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,43 @@
+project_name: thriftcheck
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: thriftcheck
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    main: ./cmd/
+    ldflags:
+      - "-s -w -X main.version={{ .Version }} -X main.revision={{ .ShortCommit }}"
+
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      darwin: macos
+
+snapshot:
+  name_template: "{{ .Tag }}-dev"
+
+release:
+  github:
+    owner: pinterest
+    name: thriftcheck
+  prerelease: auto
+  name_template: '{{ .Tag }}'
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^.github:'
+      - README.md

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -62,11 +62,14 @@ func (i *Includes) Set(value string) error {
 }
 
 var (
+	version     = "dev"
+	revision    = "dev"
 	includes    Includes
 	configFile  = flag.String("c", "thriftcheck.toml", "configuration file path")
 	helpFlag    = flag.Bool("h", false, "show command help")
 	listFlag    = flag.Bool("l", false, "list all available checks")
 	verboseFlag = flag.Bool("v", false, "enable verbose (debugging) output")
+	versionFlag = flag.Bool("version", false, "print the version and exit")
 )
 
 func init() {
@@ -116,6 +119,10 @@ func main() {
 	getopt.Parse()
 	if *helpFlag {
 		flag.Usage()
+		os.Exit(0)
+	}
+	if *versionFlag {
+		fmt.Fprintf(flag.CommandLine.Output(), "thriftcheck %s (%s)\n", version, revision)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This also includes support for a `--version` command line flag.