### PR TITLE
Rename 'includes' to 'include.exists'

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ warning = 500
 error = 1000
 ```
 
-### `includes`
+### `include.exists`
 
 This check ensures that each `include`'d file can be located in the set of
 given include paths.

--- a/checks/includes.go
+++ b/checks/includes.go
@@ -23,10 +23,10 @@ import (
 	"go.uber.org/thriftrw/ast"
 )
 
-// CheckIncludes returns a thriftcheck.Check that verifies that all of the
+// CheckIncludeExists returns a thriftcheck.Check that verifies that all of the
 // files `include`'d by a Thrift file can be found in the includes paths.
-func CheckIncludes() thriftcheck.Check {
-	return thriftcheck.NewCheck("includes", func(c *thriftcheck.C, i *ast.Include) {
+func CheckIncludeExists() thriftcheck.Check {
+	return thriftcheck.NewCheck("includes.exist", func(c *thriftcheck.C, i *ast.Include) {
 		// Always check the file's directory first to match `thrift`s behavior.
 		dirs := append([]string{filepath.Dir(c.Filename)}, c.Includes...)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -140,7 +140,7 @@ func main() {
 	// Build the set of checks we'll use for the linter
 	checks := &thriftcheck.Checks{
 		checks.CheckEnumSize(cfg.Checks.Enum.Size.Warning, cfg.Checks.Enum.Size.Error),
-		checks.CheckIncludes(),
+		checks.CheckIncludeExists(),
 		checks.CheckMapKeyType(),
 		checks.CheckNamespacePattern(cfg.Checks.Namespace.Patterns),
 		checks.CheckSetValueType(),

--- a/linter.go
+++ b/linter.go
@@ -59,6 +59,7 @@ func NewLinter(checks Checks, options ...Option) *Linter {
 		option(l)
 	}
 	l.logger.Printf("checks: %s\n", checks)
+	l.logger.Printf("includes: %s\n", strings.Join(l.includes, " "))
 	return l
 }
 


### PR DESCRIPTION
This better matches the name of the matching node ('include'), which is
consistent with the other checks' names. Also, we'll likely have other
include-based checks, so using the dot-based notation will make that
more obvious. It will also avoid any confusion with the 'nolint'
syntax's hierarchical matching.