### PR TITLE
Add a new 'include.restricted' check

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ includes = [
 ]
 ```
 
+### `include.restricted`
+
+This check restricts some files from being imported by other files using a
+map of regular expressions: the key matches the *including* filename and the
+value matches the *included* filename. When both match, the `include` is
+flagged as "restricted" and an error is reported.
+
+```toml
+[checks.include]
+[[checks.include.restricted]]
+".*" = "(huge|massive).thrift"
+```
+
 ### `map.key.type`
 
 This check ensures that only primitive types are used for `map<>` keys.

--- a/checks/includes_test.go
+++ b/checks/includes_test.go
@@ -1,0 +1,76 @@
+// Copyright 2021 Pinterest
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks_test
+
+import (
+	"testing"
+
+	"github.com/pinterest/thriftcheck/checks"
+	"go.uber.org/thriftrw/ast"
+)
+
+func TestCheckIncludeRestricted(t *testing.T) {
+	tests := []struct {
+		name string
+		node *ast.Include
+		want []string
+	}{
+		{
+			name: "a.thrift",
+			node: &ast.Include{Path: "good.thrift"},
+			want: []string{},
+		},
+		{
+			name: "a.thrift",
+			node: &ast.Include{Path: "bad.thrift"},
+			want: []string{
+				`a.thrift:0:1:error: "bad.thrift" is a restricted import (include.restricted)`,
+			},
+		},
+		{
+			name: "a.thrift",
+			node: &ast.Include{Path: "abad.thrift"},
+			want: []string{
+				`a.thrift:0:1:error: "abad.thrift" is a restricted import (include.restricted)`,
+			},
+		},
+		{
+			name: "b.thrift",
+			node: &ast.Include{Path: "bad.thrift"},
+			want: []string{
+				`b.thrift:0:1:error: "bad.thrift" is a restricted import (include.restricted)`,
+			},
+		},
+		{
+			name: "b.thrift",
+			node: &ast.Include{Path: "abad.thrift"},
+			want: []string{
+				`b.thrift:0:1:error: "abad.thrift" is a restricted import (include.restricted)`,
+			},
+		},
+	}
+
+	check := checks.CheckIncludeRestricted(map[string]string{
+		".*":       `bad.thrift`,
+		"a.thrift": `abad.thrift`,
+	})
+
+	for _, tt := range tests {
+		c := newC(&check)
+		c.Filename = tt.name
+		check.Call(c, tt.node)
+		assertMessageStrings(t, tt.node, tt.want, c.Messages)
+	}
+}

--- a/checks/namespaces.go
+++ b/checks/namespaces.go
@@ -31,7 +31,7 @@ func CheckNamespacePattern(patterns map[string]string) thriftcheck.Check {
 	}
 
 	return thriftcheck.NewCheck("namespace.patterns", func(c *thriftcheck.C, ns *ast.Namespace) {
-		if re, ok := regexps[ns.Scope]; ok && !re.Match([]byte(ns.Name)) {
+		if re, ok := regexps[ns.Scope]; ok && !re.MatchString(ns.Name) {
 			c.Errorf(ns, "%q namespace must match %q", ns.Scope, re)
 		}
 	})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,6 +42,10 @@ type Config struct {
 			}
 		}
 
+		Include struct {
+			Restricted map[string]string `fig:"restricted"`
+		}
+
 		Namespace struct {
 			Patterns map[string]string `fig:"patterns"`
 		}
@@ -141,6 +145,7 @@ func main() {
 	checks := &thriftcheck.Checks{
 		checks.CheckEnumSize(cfg.Checks.Enum.Size.Warning, cfg.Checks.Enum.Size.Error),
 		checks.CheckIncludeExists(),
+		checks.CheckIncludeRestricted(cfg.Checks.Include.Restricted),
 		checks.CheckMapKeyType(),
 		checks.CheckNamespacePattern(cfg.Checks.Namespace.Patterns),
 		checks.CheckSetValueType(),

--- a/cmd/thriftcheck.example.toml
+++ b/cmd/thriftcheck.example.toml
@@ -17,11 +17,15 @@ disabled = []
 
 # Configuration values for specific checks:
 
-[checks.namespace]
-[[checks.namespace.patterns]]
-py = "^idl\\."
-
 [checks.enum]
 [checks.enum.size]
 warning = 500
 error = 1000
+
+[checks.include]
+[[checks.include.restricted]]
+".*" = "(huge|massive).thrift"
+
+[checks.namespace]
+[[checks.namespace.patterns]]
+py = "^idl\\."


### PR DESCRIPTION
This check restricts some files from being imported by other files using
a map of regular expressions: the key matches the including filename and
the value matches the included filename. When both match, the `include`
is flagged as "restricted" and an error is reported.