### PR TITLE
Use filepath.Match() to match keys in include.restricted

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,15 @@ includes = [
 ### `include.restricted`
 
 This check restricts some files from being imported by other files using a
-map of regular expressions: the key matches the *including* filename and the
-value matches the *included* filename. When both match, the `include` is
-flagged as "restricted" and an error is reported.
+map of patterns: the key is a file name pattern that matches the *including*
+filename and the value is a regular expression that matches the *included*
+filename. When both match, the `include` is flagged as "restricted" and an
+error is reported.
 
 ```toml
 [checks.include]
 [[checks.include.restricted]]
-".*" = "(huge|massive).thrift"
+"*" = "(huge|massive).thrift"
 ```
 
 ### `map.key.type`

--- a/checks/includes.go
+++ b/checks/includes.go
@@ -45,20 +45,20 @@ func CheckIncludeExists() thriftcheck.Check {
 }
 
 // CheckIncludeRestricted returns a thriftcheck.Check that restricts some files
-// from being imported by other  files using a map of regular expressions: the
-// key matches the including filename and the value matches the included
-// filename. When both match, the `include` is flagged as "restricted" and an
-// error is reported.
+// from being imported by other  files using a map of patterns: the key is a
+// file name pattern that matches the including filename and the value is a
+// regular expression that matches the included filename. When both match, the
+// `include` is flagged as "restricted" and an error is reported.
 func CheckIncludeRestricted(patterns map[string]string) thriftcheck.Check {
-	regexps := make(map[*regexp.Regexp]*regexp.Regexp, len(patterns))
+	regexps := make(map[string]*regexp.Regexp, len(patterns))
 	for fpat, ipat := range patterns {
-		regexps[regexp.MustCompile(fpat)] = regexp.MustCompile(ipat)
+		regexps[fpat] = regexp.MustCompile(ipat)
 	}
 
 	return thriftcheck.NewCheck("include.restricted", func(c *thriftcheck.C, i *ast.Include) {
-		for fre, ire := range regexps {
-			if fre.MatchString(c.Filename) && ire.MatchString(i.Path) {
-				c.Logger.Printf("%q (%s) matches %q (%s)\n", c.Filename, fre, i.Path, ire)
+		for fpat, ire := range regexps {
+			if ok, _ := filepath.Match(fpat, c.Filename); ok && ire.MatchString(i.Path) {
+				c.Logger.Printf("%q (%s) matches %q (%s)\n", c.Filename, fpat, i.Path, ire)
 				c.Errorf(i, "%q is a restricted import", i.Path)
 				return
 			}

--- a/checks/includes_test.go
+++ b/checks/includes_test.go
@@ -63,7 +63,7 @@ func TestCheckIncludeRestricted(t *testing.T) {
 	}
 
 	check := checks.CheckIncludeRestricted(map[string]string{
-		".*":       `bad.thrift`,
+		"*":        `bad.thrift`,
 		"a.thrift": `abad.thrift`,
 	})
 

--- a/cmd/thriftcheck.example.toml
+++ b/cmd/thriftcheck.example.toml
@@ -24,7 +24,7 @@ error = 1000
 
 [checks.include]
 [[checks.include.restricted]]
-".*" = "(huge|massive).thrift"
+"*" = "(huge|massive).thrift"
 
 [checks.namespace]
 [[checks.namespace.patterns]]


### PR DESCRIPTION
The previous regular expression syntax was a bit heavy for the left-hand
side of this table. We can instead use the simpler file name pattern
syntax.

I'm keeping the richer regular expression syntax for the right-hand side
because it gives us a nice way to match multiple unrelated files using
groups. The alternative would be to express the configuration block as a
list of (pattern, pattern) pairs (rather than a map), which would allow
repeated left-hand side values, but that doesn't feel like the right
trade-off.