### PR TITLE
Standardize the checks unit test pattern

### DIFF
--- a/checks/enums_test.go
+++ b/checks/enums_test.go
@@ -22,10 +22,7 @@ import (
 )
 
 func TestCheckEnumSize(t *testing.T) {
-	tests := []struct {
-		node *ast.Enum
-		want []string
-	}{
+	tests := []Test{
 		{
 			node: &ast.Enum{Name: "enum"},
 			want: []string{},
@@ -45,10 +42,5 @@ func TestCheckEnumSize(t *testing.T) {
 	}
 
 	check := checks.CheckEnumSize(1, 2)
-
-	for _, tt := range tests {
-		c := newC(&check)
-		check.Call(c, tt.node)
-		assertMessageStrings(t, tt.node, tt.want, c.Messages)
-	}
+	RunTests(t, &check, tests)
 }

--- a/checks/fields_test.go
+++ b/checks/fields_test.go
@@ -22,10 +22,7 @@ import (
 )
 
 func TestCheckFieldIDMissing(t *testing.T) {
-	tests := []struct {
-		node *ast.Field
-		want []string
-	}{
+	tests := []Test{
 		{
 			node: &ast.Field{ID: 1},
 			want: []string{},
@@ -39,19 +36,11 @@ func TestCheckFieldIDMissing(t *testing.T) {
 	}
 
 	check := checks.CheckFieldIDMissing()
-
-	for _, tt := range tests {
-		c := newC(&check)
-		check.Call(c, tt.node)
-		assertMessageStrings(t, tt.node, tt.want, c.Messages)
-	}
+	RunTests(t, &check, tests)
 }
 
 func TestCheckFieldIDNegative(t *testing.T) {
-	tests := []struct {
-		node *ast.Field
-		want []string
-	}{
+	tests := []Test{
 		{
 			node: &ast.Field{ID: 1, Name: "Field"},
 			want: []string{},
@@ -69,10 +58,5 @@ func TestCheckFieldIDNegative(t *testing.T) {
 	}
 
 	check := checks.CheckFieldIDNegative()
-
-	for _, tt := range tests {
-		c := newC(&check)
-		check.Call(c, tt.node)
-		assertMessageStrings(t, tt.node, tt.want, c.Messages)
-	}
+	RunTests(t, &check, tests)
 }

--- a/checks/includes_test.go
+++ b/checks/includes_test.go
@@ -22,11 +22,7 @@ import (
 )
 
 func TestCheckIncludeRestricted(t *testing.T) {
-	tests := []struct {
-		name string
-		node *ast.Include
-		want []string
-	}{
+	tests := []Test{
 		{
 			name: "a.thrift",
 			node: &ast.Include{Path: "good.thrift"},
@@ -66,11 +62,5 @@ func TestCheckIncludeRestricted(t *testing.T) {
 		"*":        `bad.thrift`,
 		"a.thrift": `abad.thrift`,
 	})
-
-	for _, tt := range tests {
-		c := newC(&check)
-		c.Filename = tt.name
-		check.Call(c, tt.node)
-		assertMessageStrings(t, tt.node, tt.want, c.Messages)
-	}
+	RunTests(t, &check, tests)
 }

--- a/checks/maps_test.go
+++ b/checks/maps_test.go
@@ -22,11 +22,7 @@ import (
 )
 
 func TestCheckMapKeyType(t *testing.T) {
-	tests := []struct {
-		prog *ast.Program
-		node ast.MapType
-		want []string
-	}{
+	tests := []Test{
 		{
 			node: ast.MapType{
 				KeyType:   ast.BaseType{ID: ast.StringTypeID},
@@ -64,11 +60,5 @@ func TestCheckMapKeyType(t *testing.T) {
 	}
 
 	check := checks.CheckMapKeyType()
-
-	for _, tt := range tests {
-		c := newC(&check)
-		c.Program = tt.prog
-		check.Call(c, tt.node)
-		assertMessageStrings(t, tt.node, tt.want, c.Messages)
-	}
+	RunTests(t, &check, tests)
 }

--- a/checks/namespaces_test.go
+++ b/checks/namespaces_test.go
@@ -22,10 +22,7 @@ import (
 )
 
 func TestCheckNamespacePattern(t *testing.T) {
-	tests := []struct {
-		node *ast.Namespace
-		want []string
-	}{
+	tests := []Test{
 		{
 			node: &ast.Namespace{Scope: "java", Name: "com.pinterest.idl.test"},
 			want: []string{},
@@ -41,10 +38,5 @@ func TestCheckNamespacePattern(t *testing.T) {
 	check := checks.CheckNamespacePattern(map[string]string{
 		"java": `^com\.pinterest\.idl\.`,
 	})
-
-	for _, tt := range tests {
-		c := newC(&check)
-		check.Call(c, tt.node)
-		assertMessageStrings(t, tt.node, tt.want, c.Messages)
-	}
+	RunTests(t, &check, tests)
 }

--- a/checks/sets_test.go
+++ b/checks/sets_test.go
@@ -22,11 +22,7 @@ import (
 )
 
 func TestCheckSetValueType(t *testing.T) {
-	tests := []struct {
-		prog *ast.Program
-		node ast.SetType
-		want []string
-	}{
+	tests := []Test{
 		{
 			node: ast.SetType{ValueType: ast.BaseType{ID: ast.StringTypeID}},
 			want: []string{},
@@ -54,11 +50,5 @@ func TestCheckSetValueType(t *testing.T) {
 	}
 
 	check := checks.CheckSetValueType()
-
-	for _, tt := range tests {
-		c := newC(&check)
-		c.Program = tt.prog
-		check.Call(c, tt.node)
-		assertMessageStrings(t, tt.node, tt.want, c.Messages)
-	}
+	RunTests(t, &check, tests)
 }


### PR DESCRIPTION
All checks tests now use a common Test struct and run their tests via a
RunTests() helper function.