### PR TITLE
Report parse errors are first-class error messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/pelletier/go-toml v1.9.1 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
-	go.uber.org/thriftrw v1.27.1-0.20210526003727-4b3602d7ee91
+	go.uber.org/thriftrw v1.27.1-0.20210609205117-43bf956f2ea0
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	rsc.io/getopt v0.0.0-20170811000552-20be20937449

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
-go.uber.org/thriftrw v1.27.1-0.20210526003727-4b3602d7ee91 h1:u4A3OQ9M9qr/NpICXx/MEkG+HkYTh16nJpeJHZ5hmg8=
-go.uber.org/thriftrw v1.27.1-0.20210526003727-4b3602d7ee91/go.mod h1:IcIfSeZgc59AlYb0xr0DlDKIdD7SgjnFpG9BXCPyy9g=
+go.uber.org/thriftrw v1.27.1-0.20210609205117-43bf956f2ea0 h1:vCZbqaSe3ph8TmfY2qjBsACHdUmRwwU/DDlSR1+RRDc=
+go.uber.org/thriftrw v1.27.1-0.20210609205117-43bf956f2ea0/go.mod h1:IcIfSeZgc59AlYb0xr0DlDKIdD7SgjnFpG9BXCPyy9g=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
Previously, parse errors were written using an ad hoc error format. Now
that thriftrw-go can returns a structured idl.ParseError, we can unpack
that and report a complete error message.