### PR TITLE
Add a new int.64bit check

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ error is reported.
 "*" = "(huge|massive).thrift"
 ```
 
+### `int.64bit`
+
+This check warns when an integer constant exceeds the 32-bit number range.
+Some languages (e.g. JavaScript) don't support 64-bit integers.
+
 ### `map.key.type`
 
 This check ensures that only primitive types are used for `map<>` keys.

--- a/checks/ints.go
+++ b/checks/ints.go
@@ -1,0 +1,31 @@
+// Copyright 2021 Pinterest
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"math"
+
+	"github.com/pinterest/thriftcheck"
+	"go.uber.org/thriftrw/ast"
+)
+
+// CheckInteger64bit warns when an integer constant exceeds the 32-bit number range.
+func CheckInteger64bit() *thriftcheck.Check {
+	return thriftcheck.NewCheck("int.64bit", func(c *thriftcheck.C, i ast.ConstantInteger) {
+		if i < math.MinInt32 || i > math.MaxInt32 {
+			c.Warningf(i, "64-bit integer constant %d may not work in all languages", i)
+		}
+	})
+}

--- a/checks/ints_test.go
+++ b/checks/ints_test.go
@@ -1,0 +1,47 @@
+// Copyright 2021 Pinterest
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/pinterest/thriftcheck/checks"
+	"go.uber.org/thriftrw/ast"
+)
+
+func TestCheckInteger64bit(t *testing.T) {
+	tests := []Test{
+		{
+			node: ast.ConstantInteger(0),
+			want: []string{},
+		},
+		{
+			node: ast.ConstantInteger(math.MinInt32 - 1),
+			want: []string{
+				`t.thrift:0:1:warning: 64-bit integer constant -2147483649 may not work in all languages (int.64bit)`,
+			},
+		},
+		{
+			node: ast.ConstantInteger(math.MaxInt32 + 1),
+			want: []string{
+				`t.thrift:0:1:warning: 64-bit integer constant 2147483648 may not work in all languages (int.64bit)`,
+			},
+		},
+	}
+
+	check := checks.CheckInteger64bit()
+	RunTests(t, check, tests)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -149,6 +149,7 @@ func main() {
 		checks.CheckFieldIDNegative(),
 		checks.CheckIncludePath(),
 		checks.CheckIncludeRestricted(cfg.Checks.Include.Restricted),
+		checks.CheckInteger64bit(),
 		checks.CheckMapKeyType(),
 		checks.CheckNamespacePattern(cfg.Checks.Namespace.Patterns),
 		checks.CheckSetValueType(),


### PR DESCRIPTION
This check warns when an integer constant exceeds the 32-bit number
range. Some languages (e.g. JavaScript) don't support 64-bit integers.