### PR TITLE
Report line numbers for parse errors

### DIFF
--- a/linter.go
+++ b/linter.go
@@ -75,6 +75,7 @@ func (l *Linter) Lint(r io.Reader, filename string) (Messages, error) {
 			for i, err := range parseError.Errors {
 				msgs[i] = Message{
 					Filename: filename,
+					Line:     err.Pos.Line,
 					Check:    "parse",
 					Severity: Error,
 					Message:  err.Err.Error(),

--- a/linter_test.go
+++ b/linter_test.go
@@ -88,13 +88,13 @@ func TestParseError(t *testing.T) {
 		{
 			s: `namespace`,
 			want: []string{
-				`t.thrift:0:1:error: syntax error: unexpected $end, expecting IDENTIFIER or '*' (parse)`,
+				`t.thrift:1:1:error: syntax error: unexpected $end, expecting IDENTIFIER or '*' (parse)`,
 			},
 		},
 		{
 			s: `struct S {}}`,
 			want: []string{
-				`t.thrift:0:1:error: syntax error: unexpected '}' (parse)`,
+				`t.thrift:1:1:error: syntax error: unexpected '}' (parse)`,
 			},
 		},
 	}


### PR DESCRIPTION
Now that thriftrw supports line numbers in parse errors, we can include
that information as part of our own reports.