### PR TITLE
Use parsed idl.Info to determine node positions

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -58,7 +58,7 @@ func Resolve(ref ast.TypeReference, program *ast.Program, dirs []string) (ast.No
 
 	if strings.Contains(name, ".") {
 		parts := strings.SplitN(name, ".", 2)
-		program, err := ParseFile(parts[0]+".thrift", dirs)
+		program, _, err := ParseFile(parts[0]+".thrift", dirs)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/pelletier/go-toml v1.9.1 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
-	go.uber.org/thriftrw v1.27.1-0.20210622170742-369aed6e25db
+	go.uber.org/thriftrw v1.27.1-0.20210625163406-e4bf17f70eb1
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	rsc.io/getopt v0.0.0-20170811000552-20be20937449

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
-go.uber.org/thriftrw v1.27.1-0.20210622170742-369aed6e25db h1:dfdnIqf+aaZ7/PlTfRaxRxrqwV+iLRLq+04iSI4mgGY=
-go.uber.org/thriftrw v1.27.1-0.20210622170742-369aed6e25db/go.mod h1:IcIfSeZgc59AlYb0xr0DlDKIdD7SgjnFpG9BXCPyy9g=
+go.uber.org/thriftrw v1.27.1-0.20210625163406-e4bf17f70eb1 h1:HbHgZlvaUQjk+G4F0HYKo/XCkeqR/3wDjfxsWbloByQ=
+go.uber.org/thriftrw v1.27.1-0.20210625163406-e4bf17f70eb1/go.mod h1:IcIfSeZgc59AlYb0xr0DlDKIdD7SgjnFpG9BXCPyy9g=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/linter_test.go
+++ b/linter_test.go
@@ -232,7 +232,7 @@ func TestNoLint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			actual := map[ast.Node][]string{}
-			for _, m := range linter.lint(tt.node, "filename.thrift") {
+			for _, m := range linter.lint(tt.node, "filename.thrift", nil) {
 				if _, ok := m.Node.(*ast.Program); !ok {
 					actual[m.Node] = append(actual[m.Node], m.Check)
 				}

--- a/message.go
+++ b/message.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"go.uber.org/thriftrw/ast"
+	"go.uber.org/thriftrw/idl"
 )
 
 // Severity represents the severity level of a message.
@@ -40,7 +41,7 @@ func (s Severity) String() string {
 // Message is a message produced by a Check.
 type Message struct {
 	Filename string
-	Line     int
+	Pos      idl.Position
 	Node     ast.Node
 	Check    string
 	Severity Severity
@@ -48,7 +49,7 @@ type Message struct {
 }
 
 func (m Message) String() string {
-	return fmt.Sprintf("%s:%d:%d:%s: %s (%s)", m.Filename, m.Line, 1, m.Severity, m.Message, m.Check)
+	return fmt.Sprintf("%s:%d:%d:%s: %s (%s)", m.Filename, m.Pos.Line, 1, m.Severity, m.Message, m.Check)
 }
 
 // Messages is a list of messages.

--- a/message_test.go
+++ b/message_test.go
@@ -16,6 +16,8 @@ package thriftcheck
 
 import (
 	"testing"
+
+	"go.uber.org/thriftrw/idl"
 )
 
 func TestMessageString(t *testing.T) {
@@ -24,11 +26,11 @@ func TestMessageString(t *testing.T) {
 		s string
 	}{
 		{
-			&Message{Filename: "a.thrift", Line: 5, Check: "check", Severity: Warning, Message: "Warning"},
+			&Message{Filename: "a.thrift", Pos: idl.Position{Line: 5}, Check: "check", Severity: Warning, Message: "Warning"},
 			"a.thrift:5:1:warning: Warning (check)",
 		},
 		{
-			&Message{Filename: "a.thrift", Line: 5, Check: "check", Severity: Error, Message: "Error"},
+			&Message{Filename: "a.thrift", Pos: idl.Position{Line: 5}, Check: "check", Severity: Error, Message: "Error"},
 			"a.thrift:5:1:error: Error (check)",
 		},
 	}

--- a/parse.go
+++ b/parse.go
@@ -26,21 +26,24 @@ import (
 )
 
 // Parse parses Thrift document content.
-func Parse(r io.Reader) (*ast.Program, error) {
+func Parse(r io.Reader) (*ast.Program, *idl.Info, error) {
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return idl.Parse(b)
+
+	cfg := idl.Config{Info: &idl.Info{}}
+	prog, err := cfg.Parse(b)
+	return prog, cfg.Info, err
 }
 
 // ParseFile parses a Thrift file. The filename must appear in one of the
 // given directories.
-func ParseFile(filename string, dirs []string) (*ast.Program, error) {
+func ParseFile(filename string, dirs []string) (*ast.Program, *idl.Info, error) {
 	for _, dir := range dirs {
 		if f, err := os.Open(path.Join(dir, filename)); err == nil {
 			return Parse(f)
 		}
 	}
-	return nil, fmt.Errorf("%s not found in %s", filename, dirs)
+	return nil, nil, fmt.Errorf("%s not found in %s", filename, dirs)
 }


### PR DESCRIPTION
This switches to thriftrw's new Config-based parsing system, which
provides an idl.Info structure containing supplemental node positions
for AST types that don't support ast.LineNumber() natively.