### PR TITLE
Support ast.Position column numbers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/pelletier/go-toml v1.9.1 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
-	go.uber.org/thriftrw v1.27.1-0.20210625193054-c63ad44bef97
+	go.uber.org/thriftrw v1.27.1-0.20210628223346-89863be78a0a
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	rsc.io/getopt v0.0.0-20170811000552-20be20937449

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
-go.uber.org/thriftrw v1.27.1-0.20210625193054-c63ad44bef97 h1:bUyeb1F7tHF2OYGtO19pZ7/0iJgHcJZ41sZHF/DqlIc=
-go.uber.org/thriftrw v1.27.1-0.20210625193054-c63ad44bef97/go.mod h1:IcIfSeZgc59AlYb0xr0DlDKIdD7SgjnFpG9BXCPyy9g=
+go.uber.org/thriftrw v1.27.1-0.20210628223346-89863be78a0a h1:cX6EO1mnbtpKLjL7FaG3Zf8s9aAbBTKvfMKwLM4iDtU=
+go.uber.org/thriftrw v1.27.1-0.20210628223346-89863be78a0a/go.mod h1:IcIfSeZgc59AlYb0xr0DlDKIdD7SgjnFpG9BXCPyy9g=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/linter_test.go
+++ b/linter_test.go
@@ -94,7 +94,7 @@ func TestParseError(t *testing.T) {
 		{
 			s: `struct S {}}`,
 			want: []string{
-				`t.thrift:1:1:error: syntax error: unexpected '}' (parse)`,
+				`t.thrift:1:12:error: syntax error: unexpected '}' (parse)`,
 			},
 		},
 	}

--- a/message.go
+++ b/message.go
@@ -48,7 +48,11 @@ type Message struct {
 }
 
 func (m Message) String() string {
-	return fmt.Sprintf("%s:%d:%d:%s: %s (%s)", m.Filename, m.Pos.Line, 1, m.Severity, m.Message, m.Check)
+	col := m.Pos.Column
+	if col == 0 {
+		col = 1
+	}
+	return fmt.Sprintf("%s:%d:%d:%s: %s (%s)", m.Filename, m.Pos.Line, col, m.Severity, m.Message, m.Check)
 }
 
 // Messages is a list of messages.


### PR DESCRIPTION
These are currently only available for parse errors, but wider
node-level support will come next.

We continue to display 1 (instead of 0) in our message output when
column information isn't available.