### PR TITLE
Use fnmatch()-style file path matching

### DIFF
--- a/checks/includes.go
+++ b/checks/includes.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/danwakefield/fnmatch"
 	"github.com/pinterest/thriftcheck"
 	"go.uber.org/thriftrw/ast"
 )
@@ -57,7 +58,7 @@ func CheckIncludeRestricted(patterns map[string]string) *thriftcheck.Check {
 
 	return thriftcheck.NewCheck("include.restricted", func(c *thriftcheck.C, i *ast.Include) {
 		for fpat, ire := range regexps {
-			if ok, _ := filepath.Match(fpat, c.Filename); ok && ire.MatchString(i.Path) {
+			if fnmatch.Match(fpat, c.Filename, fnmatch.FNM_NOESCAPE) && ire.MatchString(i.Path) {
 				c.Logf("%q (%s) matches %q (%s)\n", c.Filename, fpat, i.Path, ire)
 				c.Errorf(i, "%q is a restricted import", i.Path)
 				return

--- a/checks/includes_test.go
+++ b/checks/includes_test.go
@@ -56,11 +56,31 @@ func TestCheckIncludeRestricted(t *testing.T) {
 				`b.thrift:0:1:error: "abad.thrift" is a restricted import (include.restricted)`,
 			},
 		},
+		{
+			name: "nested/a.thrift",
+			node: &ast.Include{Path: "good.thrift"},
+			want: []string{},
+		},
+		{
+			name: "nested/a.thrift",
+			node: &ast.Include{Path: "bad.thrift"},
+			want: []string{
+				`nested/a.thrift:0:1:error: "bad.thrift" is a restricted import (include.restricted)`,
+			},
+		},
+		{
+			name: "nested/a.thrift",
+			node: &ast.Include{Path: "inner.thrift"},
+			want: []string{
+				`nested/a.thrift:0:1:error: "inner.thrift" is a restricted import (include.restricted)`,
+			},
+		},
 	}
 
 	check := checks.CheckIncludeRestricted(map[string]string{
-		"*":        `bad.thrift`,
-		"a.thrift": `abad.thrift`,
+		"*":               `bad.thrift`,
+		"a.thrift":        `abad.thrift`,
+		"nested/*.thrift": `inner.thrift`,
 	})
 	RunTests(t, check, tests)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pinterest/thriftcheck
 go 1.16
 
 require (
+	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964
 	github.com/kkyr/fig v0.2.0
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/pelletier/go-toml v1.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9hchkHSWYkEqJwUGisez3G1QY8Ryz0sdWrLPMGjLk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
filepath.Match() is aware of directory separators. This makes sense for
shell-style matching but isn't as convenient working with arbitrary file
paths because the directory hierarchy needs to be expressed in the
pattern.

fnmatch(3) offers a FNM_NOESCAPE flag that avoid that problem. When set,
directory separators are treated like normal characters. This is more
intuitive for our use case (and matches Python's fnmatch.fnmatch()).

We can use github.com/danwakefield/fnmatch for a Go implementation of
the fnmatch(3) matching rules.