### PR TITLE
List enabled/disabled status alongside check names

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ usage: thriftcheck [options] [file ...]
   -h, --help
     	show command help
   -l, --list
-    	list all available checks and exit
+    	list all available checks with their status and exit
   --stdin-filename string
     	filename used when piping from stdin (default "stdin")
   -v, --verbose

--- a/check.go
+++ b/check.go
@@ -137,7 +137,7 @@ func (c Checks) SortedNames() []string {
 }
 
 // With returns a copy with only those checks whose names match the given prefixes.
-func (c Checks) With(prefixes []string) *Checks {
+func (c Checks) With(prefixes []string) Checks {
 	checks := make(Checks, 0)
 	for _, check := range c {
 		for _, prefix := range prefixes {
@@ -147,11 +147,11 @@ func (c Checks) With(prefixes []string) *Checks {
 			}
 		}
 	}
-	return &checks
+	return checks
 }
 
 // Without returns a copy without those checks whose names match the given prefixes.
-func (c Checks) Without(prefixes []string) *Checks {
+func (c Checks) Without(prefixes []string) Checks {
 	checks := make(Checks, 0)
 next:
 	for _, check := range c {
@@ -162,7 +162,7 @@ next:
 		}
 		checks = append(checks, check)
 	}
-	return &checks
+	return checks
 }
 
 // C is a type passed to all check functions to provide context.

--- a/linter.go
+++ b/linter.go
@@ -125,7 +125,7 @@ func (l *Linter) lint(program *ast.Program, filename string, parseInfo *idl.Info
 	var visitor VisitorFunc
 	visitor = func(w ast.Walker, n ast.Node) VisitorFunc {
 		nodes := append([]ast.Node{n}, w.Ancestors()...)
-		checks := activeChecks.lookup(nodes[1:])
+		checks := *activeChecks.lookup(nodes[1:])
 
 		// Handle 'nolint' annotations
 		if annotations := Annotations(n); annotations != nil {
@@ -141,13 +141,13 @@ func (l *Linter) lint(program *ast.Program, filename string, parseInfo *idl.Info
 					}
 
 					checks = checks.Without(values)
-					activeChecks.add(n, checks)
+					activeChecks.add(n, &checks)
 				}
 			}
 		}
 
 		// Run all of the checks that match this part of the tree.
-		for _, check := range *checks {
+		for _, check := range checks {
 			check.Call(ctx, nodes...)
 		}
 


### PR DESCRIPTION
This gives us a quick way to see which checks are enabled or disabled
based on the current configuration.

Also, we can pass the Checks slice around by value nearly everywhere.
This is no less efficient in Go. We still use pointers to track
overrides, however.