### PR TITLE
Use current directory to resolve includes

### DIFF
--- a/check.go
+++ b/check.go
@@ -17,7 +17,6 @@ package thriftcheck
 import (
 	"fmt"
 	"log"
-	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -205,8 +204,7 @@ func (c *C) Errorf(node ast.Node, message string, args ...interface{}) {
 
 // Resolve resolves a type reference.
 func (c *C) Resolve(ref ast.TypeReference) ast.Node {
-	dirs := append([]string{filepath.Dir(c.Filename)}, c.Includes...)
-	if n, err := Resolve(ref, c.Program, dirs); err == nil {
+	if n, err := Resolve(ref, c.Program, c.Includes); err == nil {
 		return n
 	}
 	return nil
@@ -214,8 +212,7 @@ func (c *C) Resolve(ref ast.TypeReference) ast.Node {
 
 // ResolveType resolves a type reference to its target type.
 func (c *C) ResolveType(ref ast.TypeReference) ast.Node {
-	dirs := append([]string{filepath.Dir(c.Filename)}, c.Includes...)
-	if n, err := ResolveType(ref, c.Program, dirs); err == nil {
+	if n, err := ResolveType(ref, c.Program, c.Includes); err == nil {
 		return n
 	}
 	return nil


### PR DESCRIPTION
We were previously using the including file's name, which I mistakenly
thought was the `thrift` compiler's behavior. We instead need to add the
current directory as the first search path to match `thrift`.

This change also adds support for absolute paths and makes consistent
use of the `path/filepath` package for better cross-platform support.