### PR TITLE
Enable a few more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,33 @@
 linters:
   enable:
+    - errorlint
+    - exhaustive
+    - goconst
+    - godot
+    - goheader
     - goimports
+    - goprintffuncname
     - ifshort
+    - makezero
     - nilerr
+    - prealloc
+    - thelper
     - unconvert
     - unparam
     - wastedassign
+linters-settings:
+  goheader:
+    template: |-
+      Copyright {{ YEAR }} Pinterest
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.

--- a/message.go
+++ b/message.go
@@ -24,9 +24,9 @@ import (
 type Severity int
 
 const (
-	// Warning indicates a warning
+	// Warning indicates a warning.
 	Warning Severity = iota
-	// Error indicates an error
+	// Error indicates an error.
 	Error
 )
 


### PR DESCRIPTION
In particular, we now check that all source files include our Apache 2.0
license header block.