### PR TITLE
Add 'field.optional' and 'field.requiredness' checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ implicit/auto-assigning syntax).
 
 This check reports an error if a field's ID is negative.
 
+### `field.optional`
+
+This check warns if a field isn't declared as "optional", which is considered
+a best practice.
+
+### `field.requiredness`
+
+This check warns if a field isn't explicitly declared as "required" or
+"optional".
+
 ### `include.path`
 
 This check ensures that each `include`'d file can be located in the set of

--- a/checks/fields.go
+++ b/checks/fields.go
@@ -36,3 +36,21 @@ func CheckFieldIDNegative() *thriftcheck.Check {
 		}
 	})
 }
+
+// CheckFieldOptional warns if a field isn't declared as "optional".
+func CheckFieldOptional() *thriftcheck.Check {
+	return thriftcheck.NewCheck("field.optional", func(c *thriftcheck.C, f *ast.Field) {
+		if f.Requiredness != ast.Optional {
+			c.Warningf(f, `field %q (%d) should be "optional"`, f.Name, f.ID)
+		}
+	})
+}
+
+// CheckFieldRequiredness warns if a field isn't explicitly declared as "required" or "optional".
+func CheckFieldRequiredness() *thriftcheck.Check {
+	return thriftcheck.NewCheck("field.requiredness", func(c *thriftcheck.C, f *ast.Field) {
+		if f.Requiredness == ast.Unspecified {
+			c.Warningf(f, `field %q (%d) should be explicitly "required" or "optional"`, f.Name, f.ID)
+		}
+	})
+}

--- a/checks/fields_test.go
+++ b/checks/fields_test.go
@@ -60,3 +60,49 @@ func TestCheckFieldIDNegative(t *testing.T) {
 	check := checks.CheckFieldIDNegative()
 	RunTests(t, check, tests)
 }
+
+func TestCheckFieldOptional(t *testing.T) {
+	tests := []Test{
+		{
+			node: &ast.Field{ID: 1, Name: "Field", Requiredness: ast.Unspecified},
+			want: []string{
+				`t.thrift:0:1:warning: field "Field" (1) should be "optional" (field.optional)`,
+			},
+		},
+		{
+			node: &ast.Field{ID: 1, Name: "Field", Requiredness: ast.Required},
+			want: []string{
+				`t.thrift:0:1:warning: field "Field" (1) should be "optional" (field.optional)`,
+			},
+		},
+		{
+			node: &ast.Field{ID: 1, Name: "Field", Requiredness: ast.Optional},
+			want: []string{},
+		},
+	}
+
+	check := checks.CheckFieldOptional()
+	RunTests(t, check, tests)
+}
+
+func TestCheckFieldRequiredness(t *testing.T) {
+	tests := []Test{
+		{
+			node: &ast.Field{ID: 1, Name: "Field", Requiredness: ast.Unspecified},
+			want: []string{
+				`t.thrift:0:1:warning: field "Field" (1) should be explicitly "required" or "optional" (field.requiredness)`,
+			},
+		},
+		{
+			node: &ast.Field{ID: 1, Name: "Field", Requiredness: ast.Required},
+			want: []string{},
+		},
+		{
+			node: &ast.Field{ID: 1, Name: "Field", Requiredness: ast.Optional},
+			want: []string{},
+		},
+	}
+
+	check := checks.CheckFieldRequiredness()
+	RunTests(t, check, tests)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -152,6 +152,8 @@ func main() {
 		checks.CheckEnumSize(cfg.Checks.Enum.Size.Warning, cfg.Checks.Enum.Size.Error),
 		checks.CheckFieldIDMissing(),
 		checks.CheckFieldIDNegative(),
+		checks.CheckFieldOptional(),
+		checks.CheckFieldRequiredness(),
 		checks.CheckIncludePath(),
 		checks.CheckIncludeRestricted(cfg.Checks.Include.Restricted),
 		checks.CheckInteger64bit(),


### PR DESCRIPTION
`field.optional` warns if a field isn't declared as "optional", which is
considered a best practice.

`field.requireness` warns if a field isn't explicit declared as
"required" or "optional".