### PR TITLE
Fail immediately if there's a getopt parse error

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -127,7 +127,9 @@ func lint(l *thriftcheck.Linter, filenames []string) (thriftcheck.Messages, erro
 
 func main() {
 	// Parse command line flags
-	getopt.Parse()
+	if err := getopt.CommandLine.Parse(os.Args[1:]); err != nil {
+		os.Exit(1 << uint(thriftcheck.Error))
+	}
 	if *helpFlag {
 		flag.Usage()
 		os.Exit(0)


### PR DESCRIPTION
The getopt code doesn't appear to fully respect ErrorHandling so
unrecognized flags result in Usage being displayed but not an Exit().

https://github.com/rsc/getopt/blob/20be20937449f18bb9967c10d732849fb4401e63/getopt.go#L274-L277

In our application, this was causing Usage to be displayed twice.

To fix this, we catch the lower-level Parse() error and bail
immediately.