### PR TITLE
More closely match GCC-style error format

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ $ thriftlint --stdin-name filename.thrift - < filename.thrift
 Messages are reported to standard output using a familiar parseable format:
 
 ```
-file.thrift:1:1:error: "py" namespace must match "^idl\\." (namespace.pattern)
-file.thrift:3:1:error: unable to find include path for "bar.thrift" (include.path)
+file.thrift:1:1: error: "py" namespace must match "^idl\\." (namespace.pattern)
+file.thrift:3:1: error: unable to find include path for "bar.thrift" (include.path)
 ```
 
 If you only want errors (and not warnings) to be reported, you can use the

--- a/checks/enums_test.go
+++ b/checks/enums_test.go
@@ -30,13 +30,13 @@ func TestCheckEnumSize(t *testing.T) {
 		{
 			node: &ast.Enum{Name: "enum", Items: []*ast.EnumItem{{}, {}}},
 			want: []string{
-				`t.thrift:0:1:warning: enumeration "enum" has more than 1 items (enum.size)`,
+				`t.thrift:0:1: warning: enumeration "enum" has more than 1 items (enum.size)`,
 			},
 		},
 		{
 			node: &ast.Enum{Name: "enum", Items: []*ast.EnumItem{{}, {}, {}}},
 			want: []string{
-				`t.thrift:0:1:error: enumeration "enum" has more than 2 items (enum.size)`,
+				`t.thrift:0:1: error: enumeration "enum" has more than 2 items (enum.size)`,
 			},
 		},
 	}

--- a/checks/fields_test.go
+++ b/checks/fields_test.go
@@ -30,7 +30,7 @@ func TestCheckFieldIDMissing(t *testing.T) {
 		{
 			node: &ast.Field{IDUnset: true},
 			want: []string{
-				`t.thrift:0:1:error: field ID for "" is missing (field.id.missing)`,
+				`t.thrift:0:1: error: field ID for "" is missing (field.id.missing)`,
 			},
 		},
 	}
@@ -52,7 +52,7 @@ func TestCheckFieldIDNegative(t *testing.T) {
 		{
 			node: &ast.Field{ID: -1, Name: "Field"},
 			want: []string{
-				`t.thrift:0:1:error: field ID for "Field" (-1) is negative (field.id.negative)`,
+				`t.thrift:0:1: error: field ID for "Field" (-1) is negative (field.id.negative)`,
 			},
 		},
 	}
@@ -66,13 +66,13 @@ func TestCheckFieldOptional(t *testing.T) {
 		{
 			node: &ast.Field{ID: 1, Name: "Field", Requiredness: ast.Unspecified},
 			want: []string{
-				`t.thrift:0:1:warning: field "Field" (1) should be "optional" (field.optional)`,
+				`t.thrift:0:1: warning: field "Field" (1) should be "optional" (field.optional)`,
 			},
 		},
 		{
 			node: &ast.Field{ID: 1, Name: "Field", Requiredness: ast.Required},
 			want: []string{
-				`t.thrift:0:1:warning: field "Field" (1) should be "optional" (field.optional)`,
+				`t.thrift:0:1: warning: field "Field" (1) should be "optional" (field.optional)`,
 			},
 		},
 		{
@@ -90,7 +90,7 @@ func TestCheckFieldRequiredness(t *testing.T) {
 		{
 			node: &ast.Field{ID: 1, Name: "Field", Requiredness: ast.Unspecified},
 			want: []string{
-				`t.thrift:0:1:warning: field "Field" (1) should be explicitly "required" or "optional" (field.requiredness)`,
+				`t.thrift:0:1: warning: field "Field" (1) should be explicitly "required" or "optional" (field.requiredness)`,
 			},
 		},
 		{

--- a/checks/includes_test.go
+++ b/checks/includes_test.go
@@ -33,28 +33,28 @@ func TestCheckIncludeRestricted(t *testing.T) {
 			name: "a.thrift",
 			node: &ast.Include{Path: "bad.thrift"},
 			want: []string{
-				`a.thrift:0:1:error: "bad.thrift" is a restricted import (include.restricted)`,
+				`a.thrift:0:1: error: "bad.thrift" is a restricted import (include.restricted)`,
 			},
 		},
 		{
 			name: "a.thrift",
 			node: &ast.Include{Path: "abad.thrift"},
 			want: []string{
-				`a.thrift:0:1:error: "abad.thrift" is a restricted import (include.restricted)`,
+				`a.thrift:0:1: error: "abad.thrift" is a restricted import (include.restricted)`,
 			},
 		},
 		{
 			name: "b.thrift",
 			node: &ast.Include{Path: "bad.thrift"},
 			want: []string{
-				`b.thrift:0:1:error: "bad.thrift" is a restricted import (include.restricted)`,
+				`b.thrift:0:1: error: "bad.thrift" is a restricted import (include.restricted)`,
 			},
 		},
 		{
 			name: "b.thrift",
 			node: &ast.Include{Path: "abad.thrift"},
 			want: []string{
-				`b.thrift:0:1:error: "abad.thrift" is a restricted import (include.restricted)`,
+				`b.thrift:0:1: error: "abad.thrift" is a restricted import (include.restricted)`,
 			},
 		},
 		{
@@ -66,14 +66,14 @@ func TestCheckIncludeRestricted(t *testing.T) {
 			name: "nested/a.thrift",
 			node: &ast.Include{Path: "bad.thrift"},
 			want: []string{
-				`nested/a.thrift:0:1:error: "bad.thrift" is a restricted import (include.restricted)`,
+				`nested/a.thrift:0:1: error: "bad.thrift" is a restricted import (include.restricted)`,
 			},
 		},
 		{
 			name: "nested/a.thrift",
 			node: &ast.Include{Path: "inner.thrift"},
 			want: []string{
-				`nested/a.thrift:0:1:error: "inner.thrift" is a restricted import (include.restricted)`,
+				`nested/a.thrift:0:1: error: "inner.thrift" is a restricted import (include.restricted)`,
 			},
 		},
 	}

--- a/checks/ints_test.go
+++ b/checks/ints_test.go
@@ -31,13 +31,13 @@ func TestCheckInteger64bit(t *testing.T) {
 		{
 			node: ast.ConstantInteger(math.MinInt32 - 1),
 			want: []string{
-				`t.thrift:0:1:warning: 64-bit integer constant -2147483649 may not work in all languages (int.64bit)`,
+				`t.thrift:0:1: warning: 64-bit integer constant -2147483649 may not work in all languages (int.64bit)`,
 			},
 		},
 		{
 			node: ast.ConstantInteger(math.MaxInt32 + 1),
 			want: []string{
-				`t.thrift:0:1:warning: 64-bit integer constant 2147483648 may not work in all languages (int.64bit)`,
+				`t.thrift:0:1: warning: 64-bit integer constant 2147483648 may not work in all languages (int.64bit)`,
 			},
 		},
 	}

--- a/checks/maps_test.go
+++ b/checks/maps_test.go
@@ -36,7 +36,7 @@ func TestCheckMapKeyType(t *testing.T) {
 					ValueType: ast.BaseType{ID: ast.StringTypeID}},
 				ValueType: ast.BaseType{ID: ast.StringTypeID}},
 			want: []string{
-				`t.thrift:0:1:error: map key must be a primitive type (map.key.type)`,
+				`t.thrift:0:1: error: map key must be a primitive type (map.key.type)`,
 			},
 		},
 		{
@@ -45,7 +45,7 @@ func TestCheckMapKeyType(t *testing.T) {
 				KeyType:   ast.TypeReference{Name: "Enum"},
 				ValueType: ast.BaseType{ID: ast.StringTypeID}},
 			want: []string{
-				`t.thrift:0:1:error: map key must be a primitive type (map.key.type)`,
+				`t.thrift:0:1: error: map key must be a primitive type (map.key.type)`,
 			},
 		},
 		{

--- a/checks/names_test.go
+++ b/checks/names_test.go
@@ -30,7 +30,7 @@ func TestCheckNamesReserved(t *testing.T) {
 		{
 			node: &ast.Struct{Name: "reserved"},
 			want: []string{
-				`t.thrift:0:1:error: "reserved" is a reserved name (names.reserved)`,
+				`t.thrift:0:1: error: "reserved" is a reserved name (names.reserved)`,
 			},
 		},
 		{
@@ -40,7 +40,7 @@ func TestCheckNamesReserved(t *testing.T) {
 		{
 			node: &ast.Field{Name: "reserved"},
 			want: []string{
-				`t.thrift:0:1:error: "reserved" is a reserved name (names.reserved)`,
+				`t.thrift:0:1: error: "reserved" is a reserved name (names.reserved)`,
 			},
 		},
 	}

--- a/checks/namespaces_test.go
+++ b/checks/namespaces_test.go
@@ -31,7 +31,7 @@ func TestCheckNamespacePattern(t *testing.T) {
 		{
 			node: &ast.Namespace{Scope: "java", Name: "com.example.idl.test"},
 			want: []string{
-				`t.thrift:0:1:error: "java" namespace must match "^com\\.pinterest\\.idl\\." (namespace.patterns)`,
+				`t.thrift:0:1: error: "java" namespace must match "^com\\.pinterest\\.idl\\." (namespace.patterns)`,
 			},
 		},
 	}

--- a/checks/sets_test.go
+++ b/checks/sets_test.go
@@ -30,14 +30,14 @@ func TestCheckSetValueType(t *testing.T) {
 		{
 			node: ast.SetType{ValueType: ast.SetType{ValueType: ast.BaseType{ID: ast.StringTypeID}}},
 			want: []string{
-				`t.thrift:0:1:error: set value must be a primitive type (set.value.type)`,
+				`t.thrift:0:1: error: set value must be a primitive type (set.value.type)`,
 			},
 		},
 		{
 			prog: &ast.Program{},
 			node: ast.SetType{ValueType: ast.TypeReference{Name: "Enum"}},
 			want: []string{
-				`t.thrift:0:1:error: set value must be a primitive type (set.value.type)`,
+				`t.thrift:0:1: error: set value must be a primitive type (set.value.type)`,
 			},
 		},
 		{

--- a/linter_test.go
+++ b/linter_test.go
@@ -88,13 +88,13 @@ func TestParseError(t *testing.T) {
 		{
 			s: `namespace`,
 			want: []string{
-				`t.thrift:1:1:error: syntax error: unexpected $end, expecting IDENTIFIER or '*' (parse)`,
+				`t.thrift:1:1: error: syntax error: unexpected $end, expecting IDENTIFIER or '*' (parse)`,
 			},
 		},
 		{
 			s: `struct S {}}`,
 			want: []string{
-				`t.thrift:1:12:error: syntax error: unexpected '}' (parse)`,
+				`t.thrift:1:12: error: syntax error: unexpected '}' (parse)`,
 			},
 		},
 	}

--- a/message.go
+++ b/message.go
@@ -52,7 +52,7 @@ func (m Message) String() string {
 	if col == 0 {
 		col = 1
 	}
-	return fmt.Sprintf("%s:%d:%d:%s: %s (%s)", m.Filename, m.Pos.Line, col, m.Severity, m.Message, m.Check)
+	return fmt.Sprintf("%s:%d:%d: %s: %s (%s)", m.Filename, m.Pos.Line, col, m.Severity, m.Message, m.Check)
 }
 
 // Messages is a list of messages.

--- a/message_test.go
+++ b/message_test.go
@@ -27,11 +27,11 @@ func TestMessageString(t *testing.T) {
 	}{
 		{
 			&Message{Filename: "a.thrift", Pos: ast.Position{Line: 5}, Check: "check", Severity: Warning, Message: "Warning"},
-			"a.thrift:5:1:warning: Warning (check)",
+			"a.thrift:5:1: warning: Warning (check)",
 		},
 		{
 			&Message{Filename: "a.thrift", Pos: ast.Position{Line: 5}, Check: "check", Severity: Error, Message: "Error"},
-			"a.thrift:5:1:error: Error (check)",
+			"a.thrift:5:1: error: Error (check)",
 		},
 	}
 


### PR DESCRIPTION
It's more common for tools like this to include a space before the
"severity" prefix. By adopting this GCC-style format, more tools will be
able to parse our output by default without additional configuration.