### PR TITLE
Upgrade to thriftrw v1.29.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,16 @@ go 1.17
 
 require (
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kkyr/fig v0.3.0
+	go.uber.org/thriftrw v1.29.2
+	rsc.io/getopt v0.0.0-20170811000552-20be20937449
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/pelletier/go-toml v1.9.3 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
-	go.uber.org/thriftrw v1.28.1-0.20210823172204-4d7e5c58c282
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	rsc.io/getopt v0.0.0-20170811000552-20be20937449
 )

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
-go.uber.org/thriftrw v1.28.1-0.20210823172204-4d7e5c58c282 h1:N0LLwn5mkn1sUI8pTp+/8Cg8t1pcgoBWH1V1qNF6XIE=
-go.uber.org/thriftrw v1.28.1-0.20210823172204-4d7e5c58c282/go.mod h1:YcjXveberDd28/Bs34SwHy3yu85x/jB4UA2gIcz/Eo0=
+go.uber.org/thriftrw v1.29.2 h1:pRuFLzbGvTcnYwGSjizWRHlbJUzGhu84sRiL1h1kUd8=
+go.uber.org/thriftrw v1.29.2/go.mod h1:YcjXveberDd28/Bs34SwHy3yu85x/jB4UA2gIcz/Eo0=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
- https://github.com/thriftrw/thriftrw-go/releases/tag/v1.29.0
- https://github.com/thriftrw/thriftrw-go/releases/tag/v1.29.1
- https://github.com/thriftrw/thriftrw-go/releases/tag/v1.29.2