### PR TITLE
Add pre-commit hooks support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: thriftcheck
+  name: ThriftCheck
+  description: Lint Thrift IDL files
+  entry: cmd
+  language: golang
+  types: [thrift]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ If you only want errors (and not warnings) to be reported, you can use the
 `thriftcheck`'s exit code indicates whether it reported any warnings (**1**)
 or errors (**2**). Otherwise, exit code **0** is returned.
 
+### pre-commit
+
+[pre-commit](https://pre-commit.com/) support is provided. Simply add the
+following to your `.pre-commit-config.yaml` configuration file:
+
+```yaml
+- repo: https://github.com/pinterest/thriftcheck
+  rev: 1.0.0  # git revision or tag
+  hooks:
+    - id: thriftcheck
+      name: thriftcheck
+```
+
 ## Configuration
 
 Many checks are configurable via the configuration file. This file is named


### PR DESCRIPTION
pre-commit (https://pre-commit.com/) is a framework for managing and
maintaining multi-language pre-commit hooks. It allows repositories to
export "hooks" that define individual linters; source repositories can
use these exported hooks as part of their own pre-commit configuration.

By providing .pre-commit-hooks.yaml, we're able to participate in this
system, making it easy for people to use thriftcheck with pre-commit.