### PR TITLE
Add Go version 1.18 to the testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.17"]
+        go: ["1.18"]
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.17"]
+        go: ["1.17", "1.18"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Test on both 1.17 and 1.18, but lint only on 1.18.