### PR TITLE
Add a 'constant.ref' check

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ You can enable or disable checks using the configuration file's top-level
 from the full list first, and then the resulting list is filtered by the list
 of `enabled` checks. Either list can be empty (the default).
 
+### `constant.ref`
+
+This check reports an error if a referenced constant or enum value cannot be
+found in either the current scope or in an included file (using dot notation).
+
 ### `enum.size`
 
 This check warns or errors if an enumeration's element size grows beyond a

--- a/ast.go
+++ b/ast.go
@@ -48,14 +48,13 @@ func Doc(node ast.Node) string {
 	return ""
 }
 
-// Resolve resolves an ast.TypeReference to its target node.
+// Resolve resolves a named reference to its target node.
 //
 // The target can either be in the current program's scope or it can refer to
 // an included file using dot notation. Included files must exist in one of the
 // given search directories.
-func Resolve(ref ast.TypeReference, program *ast.Program, dirs []string) (ast.Node, error) {
+func Resolve(name string, program *ast.Program, dirs []string) (ast.Node, error) {
 	defs := program.Definitions
-	name := ref.Name
 
 	if strings.Contains(name, ".") {
 		parts := strings.SplitN(name, ".", 2)
@@ -71,7 +70,7 @@ func Resolve(ref ast.TypeReference, program *ast.Program, dirs []string) (ast.No
 			}
 		}
 		if ipath == "" {
-			return nil, fmt.Errorf("missing \"include\" for type reference %q", ref.Name)
+			return nil, fmt.Errorf("missing \"include\" for type reference %q", name)
 		}
 
 		program, _, err := ParseFile(ipath, dirs)
@@ -89,7 +88,7 @@ func Resolve(ref ast.TypeReference, program *ast.Program, dirs []string) (ast.No
 		}
 	}
 
-	return nil, fmt.Errorf("%q could not be resolved", ref.Name)
+	return nil, fmt.Errorf("%q could not be resolved", name)
 }
 
 // ResolveType calls Resolve and goes one step further by attempting to
@@ -97,7 +96,7 @@ func Resolve(ref ast.TypeReference, program *ast.Program, dirs []string) (ast.No
 // points to an ast.Typedef or ast.Constant, for example, and the caller
 // is primarily intererested in the target's ast.Type.
 func ResolveType(ref ast.TypeReference, program *ast.Program, dirs []string) (ast.Node, error) {
-	n, err := Resolve(ref, program, dirs)
+	n, err := Resolve(ref.Name, program, dirs)
 	if err != nil {
 		return nil, err
 	}

--- a/check.go
+++ b/check.go
@@ -202,9 +202,9 @@ func (c *C) Errorf(node ast.Node, message string, args ...interface{}) {
 	c.Messages = append(c.Messages, m)
 }
 
-// Resolve resolves a type reference.
-func (c *C) Resolve(ref ast.TypeReference) ast.Node {
-	if n, err := Resolve(ref, c.Program, c.Dirs); err == nil {
+// Resolve resolves a name.
+func (c *C) Resolve(name string) ast.Node {
+	if n, err := Resolve(name, c.Program, c.Dirs); err == nil {
 		return n
 	}
 	return nil

--- a/checks/constants.go
+++ b/checks/constants.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Pinterest
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"github.com/pinterest/thriftcheck"
+	"go.uber.org/thriftrw/ast"
+)
+
+// CheckConstantRef returns a thriftcheck.Check that ensures that a constant
+// reference's target can be resolved.
+func CheckConstantRef() *thriftcheck.Check {
+	return thriftcheck.NewCheck("constant.ref", func(c *thriftcheck.C, ref ast.ConstantReference) {
+		if c.Resolve(ref.Name) == nil {
+			c.Errorf(ref, "unable to find a constant or enum value named %q", ref.Name)
+		}
+	})
+}

--- a/checks/constants_test.go
+++ b/checks/constants_test.go
@@ -1,0 +1,51 @@
+// Copyright 2022 Pinterest
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks_test
+
+import (
+	"testing"
+
+	"github.com/pinterest/thriftcheck/checks"
+	"go.uber.org/thriftrw/ast"
+)
+
+func TestCheckConstantRef(t *testing.T) {
+	tests := []Test{
+		{
+			prog: &ast.Program{Definitions: []ast.Definition{
+				&ast.Constant{Name: "Constant"},
+			}},
+			node: ast.ConstantReference{Name: "Constant"},
+			want: []string{},
+		},
+		{
+			prog: &ast.Program{Definitions: []ast.Definition{
+				&ast.Enum{Name: "Enum"},
+			}},
+			node: ast.ConstantReference{Name: "Enum"},
+			want: []string{},
+		},
+		{
+			prog: &ast.Program{},
+			node: ast.ConstantReference{Name: "Unknown"},
+			want: []string{
+				`t.thrift:0:1: error: unable to find a constant or enum value named "Unknown" (constant.ref)`,
+			},
+		},
+	}
+
+	check := checks.CheckConstantRef()
+	RunTests(t, check, tests)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -151,6 +151,7 @@ func main() {
 
 	// Build the set of checks we'll use for the linter
 	allChecks := thriftcheck.Checks{
+		checks.CheckConstantRef(),
 		checks.CheckEnumSize(cfg.Checks.Enum.Size.Warning, cfg.Checks.Enum.Size.Error),
 		checks.CheckFieldIDMissing(),
 		checks.CheckFieldIDNegative(),


### PR DESCRIPTION
This check reports an error if a referenced constant or enum value
cannot be found in the current, or any included, file.

To support this, I've also generalized Resolve() to handle any named
reference (which includes both TypeReference and ConstantReference).