### PR TITLE
Add a 'field.id.zero' check

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ implicit/auto-assigning syntax).
 
 This check reports an error if a field's ID is negative.
 
+### `field.id.zero`
+
+This check reports an error if a field's ID is zero, which is generally
+unsupported by the Apache Thrift compiler. This is distinct from the
+`field.id.negative` check given the existence of the `--allow-neg-keys`
+Apache Thrift compiler option.
+
 ### `field.optional`
 
 This check warns if a field isn't declared as "optional", which is considered

--- a/checks/fields.go
+++ b/checks/fields.go
@@ -37,6 +37,15 @@ func CheckFieldIDNegative() *thriftcheck.Check {
 	})
 }
 
+// CheckFieldIDZero reports an error if a field's ID is zero.
+func CheckFieldIDZero() *thriftcheck.Check {
+	return thriftcheck.NewCheck("field.id.zero", func(c *thriftcheck.C, f *ast.Field) {
+		if f.ID == 0 {
+			c.Errorf(f, "field ID for %q is zero", f.Name)
+		}
+	})
+}
+
 // CheckFieldOptional warns if a field isn't declared as "optional".
 func CheckFieldOptional() *thriftcheck.Check {
 	return thriftcheck.NewCheck("field.optional", func(c *thriftcheck.C, f *ast.Field) {

--- a/checks/fields_test.go
+++ b/checks/fields_test.go
@@ -61,6 +61,28 @@ func TestCheckFieldIDNegative(t *testing.T) {
 	RunTests(t, check, tests)
 }
 
+func TestCheckFieldIDZero(t *testing.T) {
+	tests := []Test{
+		{
+			node: &ast.Field{ID: 1, Name: "Field"},
+			want: []string{},
+		},
+		{
+			node: &ast.Field{ID: 0, Name: "Field"},
+			want: []string{
+				`t.thrift:0:1: error: field ID for "Field" is zero (field.id.zero)`,
+			},
+		},
+		{
+			node: &ast.Field{ID: -1, Name: "Field"},
+			want: []string{},
+		},
+	}
+
+	check := checks.CheckFieldIDZero()
+	RunTests(t, check, tests)
+}
+
 func TestCheckFieldOptional(t *testing.T) {
 	tests := []Test{
 		{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -155,6 +155,7 @@ func main() {
 		checks.CheckEnumSize(cfg.Checks.Enum.Size.Warning, cfg.Checks.Enum.Size.Error),
 		checks.CheckFieldIDMissing(),
 		checks.CheckFieldIDNegative(),
+		checks.CheckFieldIDZero(),
 		checks.CheckFieldOptional(),
 		checks.CheckFieldRequiredness(),
 		checks.CheckIncludePath(),


### PR DESCRIPTION
This check reports an error if a field's ID is zero, which is generally
unsupported by the Apache Thrift compiler. This is distinct from the
`field.id.negative` check given the existence of the `--allow-neg-keys`
Apache Thrift compiler option.