### PR TITLE
Run `go mod tidy`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: ${{ runner.os }}-go-
     - name: Dependencies
-      run: go mod download
+      run: |
+        go mod download
+        go mod tidy -v
     - name: Build
       run: go build -v ./...
     - name: Test


### PR DESCRIPTION
This ensures that go.mod is up-to-date and doesn't contain any
unnecessary entries.