### PR TITLE
Remove 'skip-go-installation'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,14 @@ jobs:
         go: ["1.18"]
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           only-new-issues: true
-          skip-go-installation: true
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This option was removed in golangci-lint-action v3 in favor of explicitly using actions/setup-go.