### PR TITLE
🚩 add struct field comment check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist/
 *.out
 *.test
+output/*
+testdata/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 dist/
 *.out
 *.test
-output/*
-testdata/*

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ a best practice.
 This check warns if a field isn't explicitly declared as "required" or
 "optional".
 
+### `field.doc.missing`
+
+This check warns if a field is missing a documentation comment.
+
 ### `include.path`
 
 This check ensures that each `include`'d file can be located in the set of
@@ -253,7 +257,7 @@ following to your `.pre-commit-config.yaml` configuration file:
 
 ```yaml
 - repo: https://github.com/pinterest/thriftcheck
-  rev: 1.0.0  # git revision or tag
+  rev: 1.0.0 # git revision or tag
   hooks:
     - id: thriftcheck
       name: thriftcheck

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ warning = 500
 error = 1000
 ```
 
+### `field.doc.missing`
+
+This check warns if a field is missing a documentation comment.
+
 ### `field.id.missing`
 
 This check reports an error if a field's ID is missing (using the legacy
@@ -112,10 +116,6 @@ a best practice.
 
 This check warns if a field isn't explicitly declared as "required" or
 "optional".
-
-### `field.doc.missing`
-
-This check warns if a field is missing a documentation comment.
 
 ### `include.path`
 

--- a/checks/fields.go
+++ b/checks/fields.go
@@ -64,11 +64,11 @@ func CheckFieldRequiredness() *thriftcheck.Check {
 	})
 }
 
-// CheckFieldCommentMissing warns if a field doesn't have comments.
-func CheckFieldCommentMissing() *thriftcheck.Check {
-	return thriftcheck.NewCheck("field.comment.missing", func(c *thriftcheck.C, f *ast.Field) {
+// CheckFieldDocMissing if a field is missing a documentation comment.
+func CheckFieldDocMissing() *thriftcheck.Check {
+	return thriftcheck.NewCheck("field.doc.missing", func(c *thriftcheck.C, f *ast.Field) {
 		if f.Doc == "" {
-			c.Warningf(f, `field %q (%d) don't have comments`, f.Name, f.ID)
+			c.Warningf(f, `field %q (%d) is missing a documentation comment`, f.Name, f.ID)
 		}
 	})
 }

--- a/checks/fields.go
+++ b/checks/fields.go
@@ -63,3 +63,12 @@ func CheckFieldRequiredness() *thriftcheck.Check {
 		}
 	})
 }
+
+// CheckFieldCommentMissing warns if a field doesn't have comments.
+func CheckFieldCommentMissing() *thriftcheck.Check {
+	return thriftcheck.NewCheck("field.comment.missing", func(c *thriftcheck.C, f *ast.Field) {
+		if f.Doc == "" {
+			c.Warningf(f, `field %q (%d) don't have comments`, f.Name, f.ID)
+		}
+	})
+}

--- a/checks/fields_test.go
+++ b/checks/fields_test.go
@@ -146,7 +146,7 @@ func TestCheckFieldDocMissing(t *testing.T) {
 		{
 			node: &ast.Field{ID: 1, Name: "Field"},
 			want: []string{
-				`t.thrift:0:1: warning: field "Field" (1) is missing a documentation comment`,
+				`t.thrift:0:1: warning: field "Field" (1) is missing a documentation comment (field.doc.missing)`,
 			},
 		},
 	}

--- a/checks/fields_test.go
+++ b/checks/fields_test.go
@@ -137,7 +137,7 @@ func TestCheckFieldRequiredness(t *testing.T) {
 	RunTests(t, check, tests)
 }
 
-func TestCheckFieldCommentMissing(t *testing.T) {
+func TestCheckFieldDocMissing(t *testing.T) {
 	tests := []Test{
 		{
 			node: &ast.Field{ID: 1, Name: "Field", Doc: "abc"},
@@ -146,11 +146,11 @@ func TestCheckFieldCommentMissing(t *testing.T) {
 		{
 			node: &ast.Field{ID: 1, Name: "Field"},
 			want: []string{
-				`t.thrift:0:1: warning: field "Field" (1) don't have comments`,
+				`t.thrift:0:1: warning: field "Field" (1) is missing a documentation comment`,
 			},
 		},
 	}
 
-	check := checks.CheckFieldCommentMissing()
+	check := checks.CheckFieldDocMissing()
 	RunTests(t, check, tests)
 }

--- a/checks/fields_test.go
+++ b/checks/fields_test.go
@@ -136,3 +136,21 @@ func TestCheckFieldRequiredness(t *testing.T) {
 	check := checks.CheckFieldRequiredness()
 	RunTests(t, check, tests)
 }
+
+func TestCheckFieldCommentMissing(t *testing.T) {
+	tests := []Test{
+		{
+			node: &ast.Field{ID: 1, Name: "Field", Doc: "abc"},
+			want: []string{},
+		},
+		{
+			node: &ast.Field{ID: 1, Name: "Field"},
+			want: []string{
+				`t.thrift:0:1: warning: field "Field" (1) don't have comments`,
+			},
+		},
+	}
+
+	check := checks.CheckFieldCommentMissing()
+	RunTests(t, check, tests)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -158,6 +158,7 @@ func main() {
 		checks.CheckFieldIDZero(),
 		checks.CheckFieldOptional(),
 		checks.CheckFieldRequiredness(),
+		checks.CheckFieldCommentMissing(),
 		checks.CheckIncludePath(),
 		checks.CheckIncludeRestricted(cfg.Checks.Include.Restricted),
 		checks.CheckInteger64bit(),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -158,7 +158,7 @@ func main() {
 		checks.CheckFieldIDZero(),
 		checks.CheckFieldOptional(),
 		checks.CheckFieldRequiredness(),
-		checks.CheckFieldCommentMissing(),
+		checks.CheckFieldDocMissing(),
 		checks.CheckIncludePath(),
 		checks.CheckIncludeRestricted(cfg.Checks.Include.Restricted),
 		checks.CheckInteger64bit(),


### PR DESCRIPTION
As discussed in [this issue](https://github.com/pinterest/thriftcheck/issues/60) before, and based on the current implementation of `thriftrw-go`, I added a simple check for comments. This will be helpful for some code quality checks.

By the way, I added two folders to .gitignore for the purpose of compiling and including test files later.

Closes #60