### PR TITLE
Replace deprecated ioutil usage with equivalents

### DIFF
--- a/linter.go
+++ b/linter.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -56,7 +55,7 @@ func WithIncludes(includes []string) Option {
 func NewLinter(checks Checks, options ...Option) *Linter {
 	l := &Linter{
 		checks: checks,
-		logger: log.New(ioutil.Discard, "", 0),
+		logger: log.New(io.Discard, "", 0),
 	}
 	for _, option := range options {
 		option(l)

--- a/linter_test.go
+++ b/linter_test.go
@@ -15,7 +15,7 @@
 package thriftcheck
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"reflect"
 	"strings"
@@ -25,7 +25,7 @@ import (
 )
 
 func TestWithLogger(t *testing.T) {
-	logger := log.New(ioutil.Discard, "", 0)
+	logger := log.New(io.Discard, "", 0)
 	linter := NewLinter(Checks{}, WithLogger(logger))
 	if linter.logger != logger {
 		t.Errorf("expected logger to be %v, got %v", logger, linter.logger)

--- a/parse.go
+++ b/parse.go
@@ -17,7 +17,6 @@ package thriftcheck
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -27,7 +26,7 @@ import (
 
 // Parse parses Thrift document content.
 func Parse(r io.Reader) (*ast.Program, *idl.Info, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code.