### PR TITLE
Filter out nil values from allChecks

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,6 +48,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/kkyr/fig"
@@ -230,6 +231,9 @@ func main() {
 		checks.CheckNamespacePattern(cfg.Checks.Namespace.Patterns),
 		checks.CheckSetValueType(),
 	}
+	allChecks = slices.DeleteFunc(allChecks, func(c *thriftcheck.Check) bool {
+		return c == nil
+	})
 
 	checks := allChecks
 	if len(cfg.Checks.Disabled) > 0 {


### PR DESCRIPTION
allChecks could contain nil values given that the check-building functions return *Check pointer values. None of those functions return nil today, but this makes the code robust should they start doing that (perhaps to indicate their unavailability).