### PR TITLE
Return Check structures by value

### DIFF
--- a/check.go
+++ b/check.go
@@ -32,10 +32,10 @@ type Check struct {
 }
 
 // Checks is a list of checks.
-type Checks []*Check
+type Checks []Check
 
 // NewCheck creates a new Check.
-func NewCheck(name string, fn interface{}) *Check {
+func NewCheck(name string, fn interface{}) Check {
 	if fn == nil {
 		panic("check function must be a Func; got nil")
 	}
@@ -56,7 +56,7 @@ func NewCheck(name string, fn interface{}) *Check {
 		}
 	}
 
-	return &Check{Name: name, fn: fn}
+	return Check{Name: name, fn: fn}
 }
 
 // Call the check function if its arguments end with the current node in the

--- a/checks/constants.go
+++ b/checks/constants.go
@@ -21,7 +21,7 @@ import (
 
 // CheckConstantRef returns a thriftcheck.Check that ensures that a constant
 // reference's target can be resolved.
-func CheckConstantRef() *thriftcheck.Check {
+func CheckConstantRef() thriftcheck.Check {
 	return thriftcheck.NewCheck("constant.ref", func(c *thriftcheck.C, ref ast.ConstantReference) {
 		if c.ResolveConstant(ref) == nil {
 			c.Errorf(ref, "unable to find a constant or enum value named %q", ref.Name)

--- a/checks/constants_test.go
+++ b/checks/constants_test.go
@@ -52,5 +52,5 @@ func TestCheckConstantRef(t *testing.T) {
 	}
 
 	check := checks.CheckConstantRef()
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }

--- a/checks/enums.go
+++ b/checks/enums.go
@@ -21,7 +21,7 @@ import (
 
 // CheckEnumSize returns a thriftcheck.Check that warns or errors if an
 // enumeration's element size grows beyond a limit.
-func CheckEnumSize(warningLimit, errorLimit int) *thriftcheck.Check {
+func CheckEnumSize(warningLimit, errorLimit int) thriftcheck.Check {
 	return thriftcheck.NewCheck("enum.size", func(c *thriftcheck.C, e *ast.Enum) {
 		size := len(e.Items)
 		if errorLimit > 0 && size > errorLimit {

--- a/checks/enums_test.go
+++ b/checks/enums_test.go
@@ -42,5 +42,5 @@ func TestCheckEnumSize(t *testing.T) {
 	}
 
 	check := checks.CheckEnumSize(1, 2)
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }

--- a/checks/fields.go
+++ b/checks/fields.go
@@ -20,7 +20,7 @@ import (
 )
 
 // CheckFieldIDMissing reports an error if a field's ID is missing.
-func CheckFieldIDMissing() *thriftcheck.Check {
+func CheckFieldIDMissing() thriftcheck.Check {
 	return thriftcheck.NewCheck("field.id.missing", func(c *thriftcheck.C, f *ast.Field) {
 		if f.IDUnset {
 			c.Errorf(f, "field ID for %q is missing", f.Name)
@@ -29,7 +29,7 @@ func CheckFieldIDMissing() *thriftcheck.Check {
 }
 
 // CheckFieldIDNegative reports an error if a field's ID is explicitly negative.
-func CheckFieldIDNegative() *thriftcheck.Check {
+func CheckFieldIDNegative() thriftcheck.Check {
 	return thriftcheck.NewCheck("field.id.negative", func(c *thriftcheck.C, f *ast.Field) {
 		if !f.IDUnset && f.ID < 0 {
 			c.Errorf(f, "field ID for %q (%d) is negative", f.Name, f.ID)
@@ -38,7 +38,7 @@ func CheckFieldIDNegative() *thriftcheck.Check {
 }
 
 // CheckFieldIDZero reports an error if a field's ID is explicitly zero.
-func CheckFieldIDZero() *thriftcheck.Check {
+func CheckFieldIDZero() thriftcheck.Check {
 	return thriftcheck.NewCheck("field.id.zero", func(c *thriftcheck.C, f *ast.Field) {
 		if !f.IDUnset && f.ID == 0 {
 			c.Errorf(f, "field ID for %q is zero", f.Name)
@@ -47,7 +47,7 @@ func CheckFieldIDZero() *thriftcheck.Check {
 }
 
 // CheckFieldOptional warns if a field isn't declared as "optional".
-func CheckFieldOptional() *thriftcheck.Check {
+func CheckFieldOptional() thriftcheck.Check {
 	return thriftcheck.NewCheck("field.optional", func(c *thriftcheck.C, f *ast.Field) {
 		if f.Requiredness != ast.Optional {
 			c.Warningf(f, `field %q (%d) should be "optional"`, f.Name, f.ID)
@@ -56,7 +56,7 @@ func CheckFieldOptional() *thriftcheck.Check {
 }
 
 // CheckFieldRequiredness warns if a field isn't explicitly declared as "required" or "optional".
-func CheckFieldRequiredness() *thriftcheck.Check {
+func CheckFieldRequiredness() thriftcheck.Check {
 	return thriftcheck.NewCheck("field.requiredness", func(c *thriftcheck.C, f *ast.Field) {
 		if f.Requiredness == ast.Unspecified {
 			c.Warningf(f, `field %q (%d) should be explicitly "required" or "optional"`, f.Name, f.ID)
@@ -65,7 +65,7 @@ func CheckFieldRequiredness() *thriftcheck.Check {
 }
 
 // CheckFieldDocMissing warns if a field is missing a documentation comment.
-func CheckFieldDocMissing() *thriftcheck.Check {
+func CheckFieldDocMissing() thriftcheck.Check {
 	return thriftcheck.NewCheck("field.doc.missing", func(c *thriftcheck.C, f *ast.Field) {
 		if f.Doc == "" {
 			c.Warningf(f, `field %q (%d) is missing a documentation comment`, f.Name, f.ID)

--- a/checks/fields_test.go
+++ b/checks/fields_test.go
@@ -36,7 +36,7 @@ func TestCheckFieldIDMissing(t *testing.T) {
 	}
 
 	check := checks.CheckFieldIDMissing()
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }
 
 func TestCheckFieldIDNegative(t *testing.T) {
@@ -62,7 +62,7 @@ func TestCheckFieldIDNegative(t *testing.T) {
 	}
 
 	check := checks.CheckFieldIDNegative()
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }
 
 func TestCheckFieldIDZero(t *testing.T) {
@@ -88,7 +88,7 @@ func TestCheckFieldIDZero(t *testing.T) {
 	}
 
 	check := checks.CheckFieldIDZero()
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }
 
 func TestCheckFieldOptional(t *testing.T) {
@@ -112,7 +112,7 @@ func TestCheckFieldOptional(t *testing.T) {
 	}
 
 	check := checks.CheckFieldOptional()
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }
 
 func TestCheckFieldRequiredness(t *testing.T) {
@@ -134,7 +134,7 @@ func TestCheckFieldRequiredness(t *testing.T) {
 	}
 
 	check := checks.CheckFieldRequiredness()
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }
 
 func TestCheckFieldDocMissing(t *testing.T) {
@@ -152,5 +152,5 @@ func TestCheckFieldDocMissing(t *testing.T) {
 	}
 
 	check := checks.CheckFieldDocMissing()
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }

--- a/checks/includes.go
+++ b/checks/includes.go
@@ -26,7 +26,7 @@ import (
 
 // CheckIncludePath returns a thriftcheck.Check that verifies that all of the
 // files `include`'d by a Thrift file can be found in the includes paths.
-func CheckIncludePath() *thriftcheck.Check {
+func CheckIncludePath() thriftcheck.Check {
 	return thriftcheck.NewCheck("include.path", func(c *thriftcheck.C, i *ast.Include) {
 		// If the path is absolute, we don't need to check the include paths.
 		if filepath.IsAbs(i.Path) {
@@ -55,7 +55,7 @@ func CheckIncludePath() *thriftcheck.Check {
 // file name pattern that matches the including filename and the value is a
 // regular expression that matches the included filename. When both match, the
 // `include` is flagged as "restricted" and an error is reported.
-func CheckIncludeRestricted(patterns map[string]*regexp.Regexp) *thriftcheck.Check {
+func CheckIncludeRestricted(patterns map[string]*regexp.Regexp) thriftcheck.Check {
 	return thriftcheck.NewCheck("include.restricted", func(c *thriftcheck.C, i *ast.Include) {
 		for fpat, ire := range patterns {
 			if fnmatch.Match(fpat, c.Filename, fnmatch.FNM_NOESCAPE) && ire.MatchString(i.Path) {

--- a/checks/includes_test.go
+++ b/checks/includes_test.go
@@ -83,5 +83,5 @@ func TestCheckIncludeRestricted(t *testing.T) {
 		"a.thrift":        regexp.MustCompile(`abad.thrift`),
 		"nested/*.thrift": regexp.MustCompile(`inner.thrift`),
 	})
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }

--- a/checks/ints.go
+++ b/checks/ints.go
@@ -22,7 +22,7 @@ import (
 )
 
 // CheckInteger64bit warns when an integer constant exceeds the 32-bit number range.
-func CheckInteger64bit() *thriftcheck.Check {
+func CheckInteger64bit() thriftcheck.Check {
 	return thriftcheck.NewCheck("int.64bit", func(c *thriftcheck.C, i ast.ConstantInteger) {
 		if i < math.MinInt32 || i > math.MaxInt32 {
 			c.Warningf(i, "64-bit integer constant %d may not work in all languages", i)

--- a/checks/ints_test.go
+++ b/checks/ints_test.go
@@ -43,5 +43,5 @@ func TestCheckInteger64bit(t *testing.T) {
 	}
 
 	check := checks.CheckInteger64bit()
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }

--- a/checks/maps.go
+++ b/checks/maps.go
@@ -21,7 +21,7 @@ import (
 
 // CheckMapKeyType returns a thriftcheck.Check that ensures that only primitive
 // types are used for `map<>` keys.
-func CheckMapKeyType() *thriftcheck.Check {
+func CheckMapKeyType() thriftcheck.Check {
 	return thriftcheck.NewCheck("map.key.type", func(c *thriftcheck.C, mt ast.MapType) {
 		switch t := mt.KeyType.(type) {
 		case ast.BaseType:

--- a/checks/maps_test.go
+++ b/checks/maps_test.go
@@ -60,5 +60,5 @@ func TestCheckMapKeyType(t *testing.T) {
 	}
 
 	check := checks.CheckMapKeyType()
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }

--- a/checks/names.go
+++ b/checks/names.go
@@ -32,7 +32,7 @@ func nodeName(node ast.Node) string {
 }
 
 // CheckNamesReserved checks if a node's name is in the list of reserved names.
-func CheckNamesReserved(names []string) *thriftcheck.Check {
+func CheckNamesReserved(names []string) thriftcheck.Check {
 	reserved := make(map[string]bool)
 	for _, name := range names {
 		reserved[name] = true

--- a/checks/names_test.go
+++ b/checks/names_test.go
@@ -46,5 +46,5 @@ func TestCheckNamesReserved(t *testing.T) {
 	}
 
 	check := checks.CheckNamesReserved([]string{"reserved"})
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }

--- a/checks/namespaces.go
+++ b/checks/namespaces.go
@@ -24,7 +24,7 @@ import (
 // CheckNamespacePattern returns a thriftcheck.Check that ensures that a
 // namespace's name matches a regular expression pattern. The pattern can
 // be configured one a per-language basis.
-func CheckNamespacePattern(patterns map[string]*regexp.Regexp) *thriftcheck.Check {
+func CheckNamespacePattern(patterns map[string]*regexp.Regexp) thriftcheck.Check {
 	return thriftcheck.NewCheck("namespace.patterns", func(c *thriftcheck.C, ns *ast.Namespace) {
 		if re, ok := patterns[ns.Scope]; ok && !re.MatchString(ns.Name) {
 			c.Errorf(ns, "%q namespace must match %q", ns.Scope, re)

--- a/checks/namespaces_test.go
+++ b/checks/namespaces_test.go
@@ -39,5 +39,5 @@ func TestCheckNamespacePattern(t *testing.T) {
 	check := checks.CheckNamespacePattern(map[string]*regexp.Regexp{
 		"java": regexp.MustCompile(`^com\.pinterest\.idl\.`),
 	})
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }

--- a/checks/sets.go
+++ b/checks/sets.go
@@ -21,7 +21,7 @@ import (
 
 // CheckSetValueType returns a thriftcheck.Check that ensures that only primitive
 // types are used for `set<>` values.
-func CheckSetValueType() *thriftcheck.Check {
+func CheckSetValueType() thriftcheck.Check {
 	return thriftcheck.NewCheck("set.value.type", func(c *thriftcheck.C, st ast.SetType) {
 		switch t := st.ValueType.(type) {
 		case ast.BaseType:

--- a/checks/sets_test.go
+++ b/checks/sets_test.go
@@ -50,5 +50,5 @@ func TestCheckSetValueType(t *testing.T) {
 	}
 
 	check := checks.CheckSetValueType()
-	RunTests(t, check, tests)
+	RunTests(t, &check, tests)
 }

--- a/linter_test.go
+++ b/linter_test.go
@@ -245,11 +245,11 @@ func TestNoLint(t *testing.T) {
 }
 
 func TestOverrideableChecksLookup(t *testing.T) {
-	root := &Checks{&Check{Name: "root"}}
+	root := &Checks{Check{Name: "root"}}
 	pnode := &ast.Program{}
 	snode := &ast.Struct{}
 	fnode := &ast.Field{}
-	schecks := &Checks{&Check{Name: "s"}}
+	schecks := &Checks{Check{Name: "s"}}
 
 	checks := overridableChecks{root: root}
 	checks.add(snode, schecks)


### PR DESCRIPTION
In f8694f8, I switched these routines to return pointers, but I now think that was a mistake.

1. The Check structure is small (a string and interface), so passing these values is cheap.
2. Check values are immutable in practice, so this re-enforces that.
3. Returning nil from NewCheck is meaningless and will currently result in crashes. NewCheck should never fail.