### PR TITLE
Simplify the type matching implementation

### DIFF
--- a/checks/maps.go
+++ b/checks/maps.go
@@ -49,7 +49,7 @@ func CheckMapValueType(restrictedTypes []thriftcheck.ThriftType) thriftcheck.Che
 		}
 		for _, matcher := range restrictedTypes {
 			if matcher.Matches(c, mt.ValueType) {
-				c.Errorf(mt, "map value type %s is restricted", matcher.Name())
+				c.Errorf(mt, "map value type %s is restricted", matcher)
 				return
 			}
 		}

--- a/types.go
+++ b/types.go
@@ -22,9 +22,7 @@ import (
 	"go.uber.org/thriftrw/ast"
 )
 
-type typeMatcher interface {
-	Matches(c *C, n ast.Node) bool
-}
+type typeMatcher func(c *C, n ast.Node) bool
 
 // ThriftType implements fig StringUnmarshaler for automatic toml parsing.
 type ThriftType struct {
@@ -51,86 +49,63 @@ func (t *ThriftType) UnmarshalString(v string) error {
 }
 
 func (t ThriftType) Matches(c *C, n ast.Node) bool {
-	return t.matcher.Matches(c, n)
+	return t.matcher(c, n)
 }
 
 func (t ThriftType) String() string {
 	return t.name
 }
 
-// thriftTypeMatcher handles all types with unified TypeReference resolution.
-type thriftTypeMatcher struct {
-	matches func(ast.Node) bool
+var typeMatchers = map[string]typeMatcher{
+	// Collection types
+	"map":  func(c *C, n ast.Node) bool { return matchType[ast.MapType](c, n) },
+	"list": func(c *C, n ast.Node) bool { return matchType[ast.ListType](c, n) },
+	"set":  func(c *C, n ast.Node) bool { return matchType[ast.SetType](c, n) },
+
+	// Primitive types
+	"bool":   func(c *C, n ast.Node) bool { return matchBaseType(n, ast.BoolTypeID) },
+	"i8":     func(c *C, n ast.Node) bool { return matchBaseType(n, ast.I8TypeID) },
+	"i16":    func(c *C, n ast.Node) bool { return matchBaseType(n, ast.I16TypeID) },
+	"i32":    func(c *C, n ast.Node) bool { return matchBaseType(n, ast.I32TypeID) },
+	"i64":    func(c *C, n ast.Node) bool { return matchBaseType(n, ast.I64TypeID) },
+	"double": func(c *C, n ast.Node) bool { return matchBaseType(n, ast.DoubleTypeID) },
+	"string": func(c *C, n ast.Node) bool { return matchBaseType(n, ast.StringTypeID) },
+	"binary": func(c *C, n ast.Node) bool { return matchBaseType(n, ast.BinaryTypeID) },
+
+	// Structure types
+	"union":     func(c *C, n ast.Node) bool { return matchStructureType(c, n, ast.UnionType) },
+	"struct":    func(c *C, n ast.Node) bool { return matchStructureType(c, n, ast.StructType) },
+	"exception": func(c *C, n ast.Node) bool { return matchStructureType(c, n, ast.ExceptionType) },
 }
 
-func (m *thriftTypeMatcher) Matches(c *C, n ast.Node) bool {
-	if typeRef, ok := n.(ast.TypeReference); ok {
-		if resolved := c.ResolveType(typeRef); resolved != nil {
-			if resolvedType, ok := resolved.(ast.Type); ok {
-				n = resolvedType
-			} else {
-				return false
-			}
-		} else {
+// Match a generic type, resolving any type references.
+func matchType[T ast.Type](c *C, n ast.Node) bool {
+	if ref, ok := n.(ast.TypeReference); ok {
+		if n = c.ResolveType(ref); n == nil {
 			return false
 		}
 	}
-	return m.matches(n)
+
+	_, ok := n.(T)
+	return ok
 }
 
-// structureTypeMatcher matches struct-like types (union, struct, exception).
-type structureTypeMatcher struct {
-	structType ast.StructureType
-}
-
-func (m *structureTypeMatcher) Matches(c *C, n ast.Node) bool {
-	// Handle direct *ast.Struct types (when used directly)
-	if structDef, ok := n.(*ast.Struct); ok {
-		return structDef.Type == m.structType
+// Match a structure type, resolving any type references.
+func matchStructureType(c *C, n ast.Node, t ast.StructureType) bool {
+	if ref, ok := n.(ast.TypeReference); ok {
+		if n = c.ResolveType(ref); n == nil {
+			return false
+		}
 	}
 
-	// Handle TypeReference (struct/union/exception referenced by name)
-	typeRef, ok := n.(ast.TypeReference)
-	if !ok {
-		return false
-	}
-
-	// Resolve the reference to get the actual definition
-	resolved := c.ResolveType(typeRef)
-	if resolved == nil {
-		return false
-	}
-
-	if structDef, ok := resolved.(*ast.Struct); ok {
-		return structDef.Type == m.structType
+	if s, ok := n.(*ast.Struct); ok {
+		return s.Type == t
 	}
 
 	return false
 }
 
-var typeMatchers = map[string]typeMatcher{
-	// Collection types
-	"map":  &thriftTypeMatcher{func(n ast.Node) bool { _, ok := n.(ast.MapType); return ok }},
-	"list": &thriftTypeMatcher{func(n ast.Node) bool { _, ok := n.(ast.ListType); return ok }},
-	"set":  &thriftTypeMatcher{func(n ast.Node) bool { _, ok := n.(ast.SetType); return ok }},
-
-	// Primitive types
-	"bool":   &thriftTypeMatcher{func(n ast.Node) bool { return matchBaseType(n, ast.BoolTypeID) }},
-	"i8":     &thriftTypeMatcher{func(n ast.Node) bool { return matchBaseType(n, ast.I8TypeID) }},
-	"i16":    &thriftTypeMatcher{func(n ast.Node) bool { return matchBaseType(n, ast.I16TypeID) }},
-	"i32":    &thriftTypeMatcher{func(n ast.Node) bool { return matchBaseType(n, ast.I32TypeID) }},
-	"i64":    &thriftTypeMatcher{func(n ast.Node) bool { return matchBaseType(n, ast.I64TypeID) }},
-	"double": &thriftTypeMatcher{func(n ast.Node) bool { return matchBaseType(n, ast.DoubleTypeID) }},
-	"string": &thriftTypeMatcher{func(n ast.Node) bool { return matchBaseType(n, ast.StringTypeID) }},
-	"binary": &thriftTypeMatcher{func(n ast.Node) bool { return matchBaseType(n, ast.BinaryTypeID) }},
-
-	// Structure types
-	"union":     &structureTypeMatcher{ast.UnionType},
-	"struct":    &structureTypeMatcher{ast.StructType},
-	"exception": &structureTypeMatcher{ast.ExceptionType},
-}
-
-// Helper function for primitive type matching.
+// Match a BaseType.
 func matchBaseType(n ast.Node, expectedID ast.BaseTypeID) bool {
 	if baseType, ok := n.(ast.BaseType); ok {
 		return baseType.ID == expectedID

--- a/types_test.go
+++ b/types_test.go
@@ -21,16 +21,16 @@ import (
 	"go.uber.org/thriftrw/ast"
 )
 
-func parseTypes(typeNames []string) ([]TypeMatcher, error) {
-	matchers := make([]TypeMatcher, 0, len(typeNames))
+func parseTypes(typeNames []string) ([]ThriftType, error) {
+	types := make([]ThriftType, 0, len(typeNames))
 	for _, name := range typeNames {
 		var thriftType ThriftType
 		if err := thriftType.UnmarshalString(name); err != nil {
 			return nil, err
 		}
-		matchers = append(matchers, &thriftType)
+		types = append(types, thriftType)
 	}
-	return matchers, nil
+	return types, nil
 }
 
 func TestParseTypes(t *testing.T) {
@@ -83,7 +83,7 @@ func TestParseTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			matchers, err := parseTypes(tt.input)
+			types, err := parseTypes(tt.input)
 
 			if tt.expectError {
 				if err == nil {
@@ -96,8 +96,8 @@ func TestParseTypes(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if len(matchers) != tt.expectedCount {
-				t.Errorf("expected %d matchers, got %d", tt.expectedCount, len(matchers))
+			if len(types) != tt.expectedCount {
+				t.Errorf("expected %d types, got %d", tt.expectedCount, len(types))
 			}
 		})
 	}
@@ -135,16 +135,16 @@ func TestTypeMatchers_Functionality(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			matchers, err := parseTypes([]string{tt.typeName})
+			types, err := parseTypes([]string{tt.typeName})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if len(matchers) != 1 {
-				t.Fatalf("expected 1 matcher, got %d", len(matchers))
+			if len(types) != 1 {
+				t.Fatalf("expected 1 matcher, got %d", len(types))
 			}
 
-			if matchers[0].Matches(c, tt.astType) != tt.matches {
+			if types[0].Matches(c, tt.astType) != tt.matches {
 				t.Errorf("%s: expected %v", tt.name, tt.matches)
 			}
 		})


### PR DESCRIPTION
Now that we only need the exported ThriftType in the public interface,
we can simplify a few things about the implementation:

- Implement Stringer for ThriftType
- Only store the type's name within ThriftType
- Convert typeMatcher an internal function type