### PR TITLE
Close() opened files after reading

### DIFF
--- a/linter.go
+++ b/linter.go
@@ -98,6 +98,7 @@ func (l *Linter) LintFiles(filenames []string) (Messages, error) {
 		if err != nil {
 			return msgs, fmt.Errorf("%s: %w", filename, err)
 		}
+		defer f.Close()
 
 		m, err := l.Lint(f, filename)
 		if err != nil {

--- a/parse.go
+++ b/parse.go
@@ -41,6 +41,7 @@ func Parse(r io.Reader) (*ast.Program, *idl.Info, error) {
 func ParseFile(filename string, dirs []string) (*ast.Program, *idl.Info, error) {
 	if filepath.IsAbs(filename) {
 		if f, err := os.Open(filename); err == nil {
+			defer f.Close()
 			return Parse(f)
 		}
 		return nil, nil, fmt.Errorf("%s not found", filename)
@@ -48,6 +49,7 @@ func ParseFile(filename string, dirs []string) (*ast.Program, *idl.Info, error) 
 
 	for _, dir := range dirs {
 		if f, err := os.Open(filepath.Join(dir, filename)); err == nil {
+			defer f.Close()
 			return Parse(f)
 		}
 	}


### PR DESCRIPTION
This was an oversight that caused file descriptor leaks. In practice, these were cleaned up when our short-lived program exited, but this approach is now more efficient and correct.