### PR TITLE
Add a check to allow/disallow map key types

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ The supported type names include:
 - **Primitives**: `bool`, `i8`, `i16`, `i32`, `i64`, `double`, `string`, `binary`
 - **Collections**: `map`, `list`, `set`
 - **Structures**: `union`, `struct`, `exception`
+- **Enums**: `enum`
 
 ### Semantic type matching
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ For a `map<>` key, if its type is in the `disallowed` list, this check will repo
 Otherwise, provided that the `allowed` list is not empty, the check will report an error if the
 key type is not part of the `allowed` types.
 
+See the [full list of supported types](#supported-type-names). Types are [matched semantically](#semantic-type-matching).
+
 ### `map.key.type.primitive`
 
 This check ensures that only primitive types are used for `map<>` keys.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,21 @@ Some languages (e.g. JavaScript) don't support 64-bit integers.
 
 ### `map.key.type`
 
+This check can be configured to allow/disallow specific types from being used as `map<>` keys.
+
+```toml
+[checks.map]
+[[checks.map.key]]
+allowed = []
+disallowed = []
+```
+
+For a `map<>` key, if its type is in the `disallowed` list, this check will report it as an error and stop.
+Otherwise, provided that the `allowed` list is not empty, the check will report an error if the
+key type is not part of the `allowed` types.
+
+### `map.key.type.primitive`
+
 This check ensures that only primitive types are used for `map<>` keys.
 
 ### `map.value.restricted`

--- a/README.md
+++ b/README.md
@@ -177,10 +177,6 @@ key type is not part of the `allowed` types.
 
 See the [full list of supported types](#supported-type-names). Types are [matched semantically](#semantic-type-matching).
 
-### `map.key.type.primitive`
-
-This check ensures that only primitive types are used for `map<>` keys.
-
 ### `map.value.disallowed`
 
 This check allows you to disallow specific types from being used as `map<>` values. This is useful for enforcing coding standards around map usage, such as disallowing nested maps for simplicity or preventing unions as map values for serialization compatibility.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This check can be configured to allow/disallow specific types from being used as
 
 ```toml
 [checks.map]
-[[checks.map.key]]
+[checks.map.key.type]
 allowed = []
 disallowed = []
 ```

--- a/checks/maps.go
+++ b/checks/maps.go
@@ -40,26 +40,6 @@ func CheckMapKeyType(allowedTypes []thriftcheck.ThriftType, disallowedTypes []th
 	})
 }
 
-// CheckMapKeyTypePrimitive returns a thriftcheck.Check that ensures that only primitive
-// types are used for `map<>` keys.
-func CheckMapKeyTypePrimitive() thriftcheck.Check {
-	return thriftcheck.NewCheck("map.key.type.primitive", func(c *thriftcheck.C, mt ast.MapType) {
-		switch t := mt.KeyType.(type) {
-		case ast.BaseType:
-			break
-		case ast.TypeReference:
-			switch c.ResolveType(t).(type) {
-			case ast.BaseType, *ast.Enum, *ast.Typedef:
-				break
-			default:
-				c.Errorf(mt, "map key must be a primitive type")
-			}
-		default:
-			c.Errorf(mt, "map key must be a primitive type")
-		}
-	})
-}
-
 // CheckMapValueType returns a thriftcheck.Check that ensures map values don't use disallowed types.
 // The disallowedTypes slice allows configurable type disallowances.
 // Common use cases: disallow nested maps, unions, complex collections, etc.

--- a/checks/maps.go
+++ b/checks/maps.go
@@ -19,6 +19,10 @@ import (
 	"go.uber.org/thriftrw/ast"
 )
 
+// CheckMapKeyType reports an error if a disallowed map key type is used.
+// A type is disallowed if it either:
+//   - Appears in `disallowedTypes`
+//   - Does not appear in a non-empty `allowedTypes`
 func CheckMapKeyType(allowedTypes []thriftcheck.ThriftType, disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
 	return thriftcheck.NewCheck("map.key.type", func(c *thriftcheck.C, mt ast.MapType) {
 		for _, matcher := range disallowedTypes {

--- a/checks/maps.go
+++ b/checks/maps.go
@@ -40,7 +40,7 @@ func CheckMapKeyType(allowedTypes, disallowedTypes []thriftcheck.ThriftType) thr
 				return
 			}
 		}
-		c.Errorf(mt, "map key type is not in the 'allowed' list")
+		c.Errorf(mt, "map key type %q is not in the 'allowed' list", mt.KeyType)
 	})
 }
 

--- a/checks/maps.go
+++ b/checks/maps.go
@@ -23,7 +23,7 @@ func CheckMapKeyType(allowedTypes []thriftcheck.ThriftType, disallowedTypes []th
 	return thriftcheck.NewCheck("map.key.type", func(c *thriftcheck.C, mt ast.MapType) {
 		for _, matcher := range disallowedTypes {
 			if matcher.Matches(c, mt.KeyType) {
-				c.Errorf(mt, "map key type %s is disallowed", matcher)
+				c.Errorf(mt, "map key type %q is disallowed", matcher)
 				return
 			}
 		}

--- a/checks/maps.go
+++ b/checks/maps.go
@@ -23,7 +23,7 @@ import (
 // A type is disallowed if it either:
 //   - Appears in `disallowedTypes`
 //   - Does not appear in a non-empty `allowedTypes`
-func CheckMapKeyType(allowedTypes []thriftcheck.ThriftType, disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
+func CheckMapKeyType(allowedTypes, disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
 	return thriftcheck.NewCheck("map.key.type", func(c *thriftcheck.C, mt ast.MapType) {
 		for _, matcher := range disallowedTypes {
 			if matcher.Matches(c, mt.KeyType) {

--- a/checks/maps_test.go
+++ b/checks/maps_test.go
@@ -124,48 +124,6 @@ func TestCheckMapKeyType(t *testing.T) {
 	RunTests(t, &check, tests)
 }
 
-func TestCheckMapKeyTypePrimitive(t *testing.T) {
-	tests := []Test{
-		{
-			node: ast.MapType{
-				KeyType:   ast.BaseType{ID: ast.StringTypeID},
-				ValueType: ast.BaseType{ID: ast.StringTypeID}},
-			want: []string{},
-		},
-		{
-			node: ast.MapType{
-				KeyType: ast.MapType{
-					KeyType:   ast.BaseType{ID: ast.StringTypeID},
-					ValueType: ast.BaseType{ID: ast.StringTypeID}},
-				ValueType: ast.BaseType{ID: ast.StringTypeID}},
-			want: []string{
-				`t.thrift:0:1: error: map key must be a primitive type (map.key.type.primitive)`,
-			},
-		},
-		{
-			prog: &ast.Program{},
-			node: ast.MapType{
-				KeyType:   ast.TypeReference{Name: "Enum"},
-				ValueType: ast.BaseType{ID: ast.StringTypeID}},
-			want: []string{
-				`t.thrift:0:1: error: map key must be a primitive type (map.key.type.primitive)`,
-			},
-		},
-		{
-			prog: &ast.Program{Definitions: []ast.Definition{
-				&ast.Enum{Name: "Enum"},
-			}},
-			node: ast.MapType{
-				KeyType:   ast.TypeReference{Name: "Enum"},
-				ValueType: ast.BaseType{ID: ast.StringTypeID}},
-			want: []string{},
-		},
-	}
-
-	check := checks.CheckMapKeyTypePrimitive()
-	RunTests(t, &check, tests)
-}
-
 func TestCheckMapValueType(t *testing.T) {
 	// Test with no disallowed types - should pass all
 	tests := []Test{

--- a/checks/maps_test.go
+++ b/checks/maps_test.go
@@ -57,7 +57,7 @@ func TestCheckMapKeyType(t *testing.T) {
 			node: ast.MapType{
 				KeyType:   ast.BaseType{ID: ast.StringTypeID},
 				ValueType: ast.BaseType{ID: ast.StringTypeID}},
-			want: []string{`t.thrift:0:1: error: map key type is not in the 'allowed' list (map.key.type)`},
+			want: []string{`t.thrift:0:1: error: map key type "string" is not in the 'allowed' list (map.key.type)`},
 		},
 	}
 

--- a/checks/maps_test.go
+++ b/checks/maps_test.go
@@ -70,7 +70,7 @@ func TestCheckMapKeyType(t *testing.T) {
 			node: ast.MapType{
 				KeyType:   ast.BaseType{ID: ast.I8TypeID},
 				ValueType: ast.BaseType{ID: ast.StringTypeID}},
-			want: []string{`t.thrift:0:1: error: map key type i8 is disallowed (map.key.type)`},
+			want: []string{`t.thrift:0:1: error: map key type "i8" is disallowed (map.key.type)`},
 		},
 		{
 			prog: &ast.Program{Definitions: []ast.Definition{
@@ -79,7 +79,7 @@ func TestCheckMapKeyType(t *testing.T) {
 			node: ast.MapType{
 				KeyType:   ast.TypeReference{Name: "Enum"},
 				ValueType: ast.BaseType{ID: ast.StringTypeID}},
-			want: []string{`t.thrift:0:1: error: map key type enum is disallowed (map.key.type)`},
+			want: []string{`t.thrift:0:1: error: map key type "enum" is disallowed (map.key.type)`},
 		},
 		{
 			node: ast.MapType{
@@ -99,7 +99,7 @@ func TestCheckMapKeyType(t *testing.T) {
 				KeyType:   ast.BaseType{ID: ast.I8TypeID},
 				ValueType: ast.BaseType{ID: ast.StringTypeID}},
 			// Disallowances have precedence over allowances.
-			want: []string{`t.thrift:0:1: error: map key type i8 is disallowed (map.key.type)`},
+			want: []string{`t.thrift:0:1: error: map key type "i8" is disallowed (map.key.type)`},
 		},
 		{
 			prog: &ast.Program{Definitions: []ast.Definition{
@@ -114,7 +114,7 @@ func TestCheckMapKeyType(t *testing.T) {
 			node: ast.MapType{
 				KeyType:   ast.BaseType{ID: ast.StringTypeID},
 				ValueType: ast.BaseType{ID: ast.StringTypeID}},
-			want: []string{`t.thrift:0:1: error: map key type string is disallowed (map.key.type)`},
+			want: []string{`t.thrift:0:1: error: map key type "string" is disallowed (map.key.type)`},
 		},
 	}
 

--- a/checks/maps_test.go
+++ b/checks/maps_test.go
@@ -23,6 +23,108 @@ import (
 )
 
 func TestCheckMapKeyType(t *testing.T) {
+	var i8Type thriftcheck.ThriftType
+	if err := i8Type.UnmarshalString("i8"); err != nil {
+		t.Fatalf("Failed to unmarshal i8 type: %v", err)
+	}
+	var enumType thriftcheck.ThriftType
+	if err := enumType.UnmarshalString("enum"); err != nil {
+		t.Fatalf("Failed to unmarshal enum type: %v", err)
+	}
+	var stringType thriftcheck.ThriftType
+	if err := stringType.UnmarshalString("string"); err != nil {
+		t.Fatalf("Failed to unmarshal string type: %v", err)
+	}
+
+	// Test with only allowed types.
+	tests := []Test{
+		{
+			node: ast.MapType{
+				KeyType:   ast.BaseType{ID: ast.I8TypeID},
+				ValueType: ast.BaseType{ID: ast.StringTypeID}},
+			want: []string{},
+		},
+		{
+			prog: &ast.Program{Definitions: []ast.Definition{
+				&ast.Enum{Name: "Enum"},
+			}},
+			node: ast.MapType{
+				KeyType:   ast.TypeReference{Name: "Enum"},
+				ValueType: ast.BaseType{ID: ast.StringTypeID}},
+			want: []string{},
+		},
+		{
+			node: ast.MapType{
+				KeyType:   ast.BaseType{ID: ast.StringTypeID},
+				ValueType: ast.BaseType{ID: ast.StringTypeID}},
+			want: []string{`t.thrift:0:1: error: map key type is not in the 'allowed' list (map.key.type)`},
+		},
+	}
+
+	check := checks.CheckMapKeyType([]thriftcheck.ThriftType{i8Type, enumType}, []thriftcheck.ThriftType{})
+	RunTests(t, &check, tests)
+
+	// Test with only disallowed types.
+	tests = []Test{
+		{
+			node: ast.MapType{
+				KeyType:   ast.BaseType{ID: ast.I8TypeID},
+				ValueType: ast.BaseType{ID: ast.StringTypeID}},
+			want: []string{`t.thrift:0:1: error: map key type i8 is disallowed (map.key.type)`},
+		},
+		{
+			prog: &ast.Program{Definitions: []ast.Definition{
+				&ast.Enum{Name: "Enum"},
+			}},
+			node: ast.MapType{
+				KeyType:   ast.TypeReference{Name: "Enum"},
+				ValueType: ast.BaseType{ID: ast.StringTypeID}},
+			want: []string{`t.thrift:0:1: error: map key type enum is disallowed (map.key.type)`},
+		},
+		{
+			node: ast.MapType{
+				KeyType:   ast.BaseType{ID: ast.StringTypeID},
+				ValueType: ast.BaseType{ID: ast.StringTypeID}},
+			want: []string{},
+		},
+	}
+
+	check = checks.CheckMapKeyType([]thriftcheck.ThriftType{}, []thriftcheck.ThriftType{i8Type, enumType})
+	RunTests(t, &check, tests)
+
+	// Test with both allowed and disallowed types.
+	tests = []Test{
+		{
+			node: ast.MapType{
+				KeyType:   ast.BaseType{ID: ast.I8TypeID},
+				ValueType: ast.BaseType{ID: ast.StringTypeID}},
+			// Disallowances have precedence over allowances.
+			want: []string{`t.thrift:0:1: error: map key type i8 is disallowed (map.key.type)`},
+		},
+		{
+			prog: &ast.Program{Definitions: []ast.Definition{
+				&ast.Enum{Name: "Enum"},
+			}},
+			node: ast.MapType{
+				KeyType:   ast.TypeReference{Name: "Enum"},
+				ValueType: ast.BaseType{ID: ast.StringTypeID}},
+			want: []string{},
+		},
+		{
+			node: ast.MapType{
+				KeyType:   ast.BaseType{ID: ast.StringTypeID},
+				ValueType: ast.BaseType{ID: ast.StringTypeID}},
+			want: []string{`t.thrift:0:1: error: map key type string is disallowed (map.key.type)`},
+		},
+	}
+
+	check = checks.CheckMapKeyType(
+		[]thriftcheck.ThriftType{i8Type, enumType},
+		[]thriftcheck.ThriftType{i8Type, stringType})
+	RunTests(t, &check, tests)
+}
+
+func TestCheckMapKeyTypePrimitive(t *testing.T) {
 	tests := []Test{
 		{
 			node: ast.MapType{
@@ -37,7 +139,7 @@ func TestCheckMapKeyType(t *testing.T) {
 					ValueType: ast.BaseType{ID: ast.StringTypeID}},
 				ValueType: ast.BaseType{ID: ast.StringTypeID}},
 			want: []string{
-				`t.thrift:0:1: error: map key must be a primitive type (map.key.type)`,
+				`t.thrift:0:1: error: map key must be a primitive type (map.key.type.primitive)`,
 			},
 		},
 		{
@@ -46,7 +148,7 @@ func TestCheckMapKeyType(t *testing.T) {
 				KeyType:   ast.TypeReference{Name: "Enum"},
 				ValueType: ast.BaseType{ID: ast.StringTypeID}},
 			want: []string{
-				`t.thrift:0:1: error: map key must be a primitive type (map.key.type)`,
+				`t.thrift:0:1: error: map key must be a primitive type (map.key.type.primitive)`,
 			},
 		},
 		{
@@ -60,7 +162,7 @@ func TestCheckMapKeyType(t *testing.T) {
 		},
 	}
 
-	check := checks.CheckMapKeyType()
+	check := checks.CheckMapKeyTypePrimitive()
 	RunTests(t, &check, tests)
 }
 

--- a/cmd/example.toml
+++ b/cmd/example.toml
@@ -27,7 +27,7 @@ error = 1000
 "*" = "(huge|massive).thrift"
 
 [checks.map]
-[[checks.map.key]]
+[checks.map.key.type]
 allowed = []
 disallowed = []
 [checks.map.value]

--- a/cmd/example.toml
+++ b/cmd/example.toml
@@ -27,6 +27,9 @@ error = 1000
 "*" = "(huge|massive).thrift"
 
 [checks.map]
+[[checks.map.key]]
+allowed = []
+disallowed = []
 [checks.map.value]
 # Restrict specific types as map values to enforce coding standards
 # Common examples:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -77,8 +77,8 @@ type Config struct {
 		Map struct {
 			Key struct {
 				Type struct {
-					AllowedTypes    []thriftcheck.ThriftType `fig:"allowed"`
-					DisallowedTypes []thriftcheck.ThriftType `fig:"disallowed"`
+					Allowed    []thriftcheck.ThriftType `fig:"allowed"`
+					Disallowed []thriftcheck.ThriftType `fig:"disallowed"`
 				}
 			}
 			Value struct {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,8 +76,10 @@ type Config struct {
 
 		Map struct {
 			Key struct {
-				AllowedTypes    []thriftcheck.ThriftType `fig:"allowed"`
-				DisallowedTypes []thriftcheck.ThriftType `fig:"disallowed"`
+				Type struct {
+					AllowedTypes    []thriftcheck.ThriftType `fig:"allowed"`
+					DisallowedTypes []thriftcheck.ThriftType `fig:"disallowed"`
+				}
 			}
 			Value struct {
 				Disallowed []thriftcheck.ThriftType `fig:"disallowed"`
@@ -240,7 +242,7 @@ func main() {
 		checks.CheckIncludePath(),
 		checks.CheckIncludeRestricted(cfg.Checks.Include.Restricted),
 		checks.CheckInteger64bit(),
-		checks.CheckMapKeyType(cfg.Checks.Map.Key.AllowedTypes, cfg.Checks.Map.Key.DisallowedTypes),
+		checks.CheckMapKeyType(cfg.Checks.Map.Key.Type.AllowedTypes, cfg.Checks.Map.Key.Type.DisallowedTypes),
 		checks.CheckMapKeyTypePrimitive(),
 		checks.CheckMapValueType(cfg.Checks.Map.Value.Disallowed),
 		checks.CheckNamesReserved(cfg.Checks.Names.Reserved),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -242,7 +242,7 @@ func main() {
 		checks.CheckIncludePath(),
 		checks.CheckIncludeRestricted(cfg.Checks.Include.Restricted),
 		checks.CheckInteger64bit(),
-		checks.CheckMapKeyType(cfg.Checks.Map.Key.Type.AllowedTypes, cfg.Checks.Map.Key.Type.DisallowedTypes),
+		checks.CheckMapKeyType(cfg.Checks.Map.Key.Type.Allowed, cfg.Checks.Map.Key.Type.Disallowed),
 		checks.CheckMapValueType(cfg.Checks.Map.Value.Disallowed),
 		checks.CheckNamesReserved(cfg.Checks.Names.Reserved),
 		checks.CheckNamespacePattern(cfg.Checks.Namespace.Patterns),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -243,7 +243,6 @@ func main() {
 		checks.CheckIncludeRestricted(cfg.Checks.Include.Restricted),
 		checks.CheckInteger64bit(),
 		checks.CheckMapKeyType(cfg.Checks.Map.Key.Type.AllowedTypes, cfg.Checks.Map.Key.Type.DisallowedTypes),
-		checks.CheckMapKeyTypePrimitive(),
 		checks.CheckMapValueType(cfg.Checks.Map.Value.Disallowed),
 		checks.CheckNamesReserved(cfg.Checks.Names.Reserved),
 		checks.CheckNamespacePattern(cfg.Checks.Namespace.Patterns),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,6 +75,10 @@ type Config struct {
 		}
 
 		Map struct {
+			Key struct {
+				AllowedTypes    []thriftcheck.ThriftType `fig:"allowed"`
+				DisallowedTypes []thriftcheck.ThriftType `fig:"disallowed"`
+			}
 			Value struct {
 				RestrictedTypes []thriftcheck.ThriftType `fig:"restricted"`
 			}
@@ -232,7 +236,8 @@ func main() {
 		checks.CheckIncludePath(),
 		checks.CheckIncludeRestricted(cfg.Checks.Include.Restricted),
 		checks.CheckInteger64bit(),
-		checks.CheckMapKeyType(),
+		checks.CheckMapKeyType(cfg.Checks.Map.Key.AllowedTypes, cfg.Checks.Map.Key.DisallowedTypes),
+		checks.CheckMapKeyTypePrimitive(),
 		checks.CheckMapValueType(cfg.Checks.Map.Value.RestrictedTypes),
 		checks.CheckNamesReserved(cfg.Checks.Names.Reserved),
 		checks.CheckNamespacePattern(cfg.Checks.Namespace.Patterns),

--- a/types.go
+++ b/types.go
@@ -74,7 +74,7 @@ var typeMatchers = map[string]typeMatcher{
 	"struct":    func(c *C, n ast.Node) bool { return matchStructureType(c, n, ast.StructType) },
 	"exception": func(c *C, n ast.Node) bool { return matchStructureType(c, n, ast.ExceptionType) },
 
-	// Other
+	// Enum types
 	"enum": func(c *C, n ast.Node) bool { return matchType[*ast.Enum](c, n) },
 }
 

--- a/types.go
+++ b/types.go
@@ -76,10 +76,13 @@ var typeMatchers = map[string]typeMatcher{
 	"union":     func(c *C, n ast.Node) bool { return matchStructureType(c, n, ast.UnionType) },
 	"struct":    func(c *C, n ast.Node) bool { return matchStructureType(c, n, ast.StructType) },
 	"exception": func(c *C, n ast.Node) bool { return matchStructureType(c, n, ast.ExceptionType) },
+
+	// Other
+	"enum": func(c *C, n ast.Node) bool { return matchType[*ast.Enum](c, n) },
 }
 
 // Match a generic type, resolving any type references.
-func matchType[T ast.Type](c *C, n ast.Node) bool {
+func matchType[T ast.Node](c *C, n ast.Node) bool {
 	if ref, ok := n.(ast.TypeReference); ok {
 		if n = c.ResolveType(ref); n == nil {
 			return false

--- a/types_test.go
+++ b/types_test.go
@@ -61,8 +61,9 @@ func TestParseTypes(t *testing.T) {
 				"map", "list", "set",
 				"bool", "i8", "i16", "i32", "i64", "double", "string", "binary",
 				"union", "struct", "exception",
+				"enum",
 			},
-			expectedCount: 14,
+			expectedCount: 15,
 		},
 		{
 			name:        "invalid type",
@@ -131,6 +132,9 @@ func TestTypeMatchers_Functionality(t *testing.T) {
 		{"union doesn't match Struct", "union", &ast.Struct{Type: ast.StructType}, false},
 		{"struct doesn't match Union", "struct", &ast.Struct{Type: ast.UnionType}, false},
 		{"exception doesn't match Union", "exception", &ast.Struct{Type: ast.UnionType}, false},
+
+		// Other
+		{"enum matches Enum", "enum", &ast.Enum{}, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds a new configurable check to allow/disallow specific types from being used as `map<>` keys.

The new check will be named `map.key.type`. That name was already taken by a different check, which will be renamed to `map.key.type.primitve`.

We wanted to add a check to only allow integers and enums as map keys. If we only added it in the 'allowed' flavor, it'd be strange, considering we already have the `map.value.restricted` check which disallows types. Sometimes it makes more sense to specify what to allow, and sometimes it makes more sense to specify what to disallow. So we're adding both options.

As future work we can update the `map.value.restricted` check to also cover both cases, to be consistent with this one. Also the `types.disallowed` check.