### PR TITLE
Use Go 1.23 as our minimum language version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.21", "1.22", "1.23", "1.24"]
+        go: ["1.23", "1.24"]
 
     steps:
       - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pinterest/thriftcheck
 
-go 1.22.1
+go 1.23
 
 require (
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964

--- a/types.go
+++ b/types.go
@@ -16,7 +16,8 @@ package thriftcheck
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 
 	"go.uber.org/thriftrw/ast"
@@ -35,11 +36,7 @@ func (t *ThriftType) UnmarshalString(v string) error {
 	name := strings.ToLower(v)
 	matcher, ok := typeMatchers[name]
 	if !ok {
-		validTypes := make([]string, 0, len(typeMatchers))
-		for k := range typeMatchers {
-			validTypes = append(validTypes, k)
-		}
-		sort.Strings(validTypes)
+		validTypes := slices.Sorted(maps.Keys(typeMatchers))
 		return fmt.Errorf("unknown type: %s, valid types are: %v", v, validTypes)
 	}
 


### PR DESCRIPTION
Go 1.23 was released about a year ago, and this version lets us use the iter, slices, and maps packages.