### PR TITLE
Make all types-based checks consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Some languages (e.g. JavaScript) don't support 64-bit integers.
 ### `map.key.type`
 
 This check restricts the types that can be used as `map<>` keys. It is
-configured with a lists of allowed and disallowed types.
+configured with lists of [allowed and disallowed types](#type-checks).
 
 ```toml
 [checks.map.key]
@@ -172,14 +172,10 @@ allowedTypes = [
 ]
 ```
 
-If the type is in the `disallowedTypes` list, this check will report an error
-stop. Otherwise, if the `allowedTypes` list is not empty, the check will report
-an error if the type is not part of the `allowedTypes` list.
-
 ### `map.value.type`
 
 This check restricts the types that can be used as `map<>` values. It is
-configured with a lists of allowed and disallowed types.
+configured with lists of [allowed and disallowed types](#type-checks).
 
 ```toml
 [checks.map.value]
@@ -189,10 +185,6 @@ disallowedTypes = [
     "i32",    # Disallow i32 as map values
 ]
 ```
-
-If the type is in the `disallowedTypes` list, this check will report an error
-stop. Otherwise, if the `allowedTypes` list is not empty, the check will report
-an error if the type is not part of the `allowedTypes` list.
 
 ### `names.reserved`
 
@@ -221,7 +213,7 @@ py = "^idl\\."
 ### `set.value.type`
 
 This check restricts the types that can be used as `set<>` values. It is
-configured with a lists of allowed and disallowed types.
+configured with lists of [allowed and disallowed types](#type-checks).
 
 ```toml
 [checks.set.value]
@@ -230,14 +222,10 @@ allowedTypes = [
 ]
 ```
 
-If the type is in the `disallowedTypes` list, this check will report an error
-stop. Otherwise, if the `allowedTypes` list is not empty, the check will report
-an error if the type is not part of the `allowedTypes` list.
-
 ### `types`
 
 This check restricts the types that can be used in all contexts. It is
-configured with a lists of allowed and disallowed types.
+configured with lists of [allowed and disallowed types](#type-checks).
 
 ```toml
 [checks.types]
@@ -246,21 +234,25 @@ disallowedTypes = [
 ]
 ```
 
-See the [full list of available types](#supported-type-names). Types are [matched semantically](#semantic-type-matching).
+## Type Checks
 
-## Supported type names
+Some checks are used to restrict the set of types that are allowed in various
+contexts, with the [`types`][] check acting globally. All of these checks use
+the same matching and configuration pattern.
 
-There are multiple checks which can be configured by specifying the types they act upon.
+If the type is in the `disallowedTypes` list, this check will report an error
+stop. Otherwise, if the `allowedTypes` list is not empty, the check will report
+an error if the type is not part of the `allowedTypes` list.
 
 The supported type names include:
+
 - **Primitives**: `bool`, `i8`, `i16`, `i32`, `i64`, `double`, `string`, `binary`
+- **Enumerations**: `enum`
 - **Collections**: `map`, `list`, `set`
 - **Structures**: `union`, `struct`, `exception`
-- **Enums**: `enum`
 
-### Semantic type matching
-
-Types are matched semantically, including resolving `typedef`s to their underlying types, so `typedef`s and other indirect type references are properly handled.
+Types are matched semantically, including resolving type definitions, so
+`typedef`s and other indirect type references are properly handled.
 
 ## Custom Checks
 

--- a/README.md
+++ b/README.md
@@ -162,35 +162,37 @@ Some languages (e.g. JavaScript) don't support 64-bit integers.
 
 ### `map.key.type`
 
-This check can be configured to allow/disallow specific types from being used as `map<>` keys.
+This check restricts the types that can be used as `map<>` keys. It is
+configured with a lists of allowed and disallowed types.
 
 ```toml
-[checks.map]
-[checks.map.key.type]
-allowed = []
-disallowed = []
+[checks.map.key]
+allowedTypes = [
+    "string", # Only allow string map keys
+]
 ```
 
-For a `map<>` key, if its type is in the `disallowed` list, this check will report it as an error and stop.
-Otherwise, provided that the `allowed` list is not empty, the check will report an error if the
-key type is not part of the `allowed` types.
+If the type is in the `disallowedTypes` list, this check will report an error
+stop. Otherwise, if the `allowedTypes` list is not empty, the check will report
+an error if the type is not part of the `allowedTypes` list.
 
-See the [full list of supported types](#supported-type-names). Types are [matched semantically](#semantic-type-matching).
+### `map.value.type`
 
-### `map.value.disallowed`
-
-This check allows you to disallow specific types from being used as `map<>` values. This is useful for enforcing coding standards around map usage, such as disallowing nested maps for simplicity or preventing unions as map values for serialization compatibility.
+This check restricts the types that can be used as `map<>` values. It is
+configured with a lists of allowed and disallowed types.
 
 ```toml
 [checks.map.value]
-disallowed = [
+disallowedTypes = [
     "union",  # Disallow unions as map values
     "map",    # Disallow nested maps
     "i32",    # Disallow i32 as map values
 ]
 ```
 
-See the [full list of supported types](#supported-type-names). Types are [matched semantically](#semantic-type-matching).
+If the type is in the `disallowedTypes` list, this check will report an error
+stop. Otherwise, if the `allowedTypes` list is not empty, the check will report
+an error if the type is not part of the `allowedTypes` list.
 
 ### `names.reserved`
 
@@ -218,15 +220,28 @@ py = "^idl\\."
 
 ### `set.value.type`
 
-This check ensures that only primitive types are used for `set<>` values.
+This check restricts the types that can be used as `set<>` values. It is
+configured with a lists of allowed and disallowed types.
 
-### `types.disallowed`
+```toml
+[checks.set.value]
+allowedTypes = [
+    "string", # Only allow string set values
+]
+```
 
-This check allows you to disallow specific types from being used.
+If the type is in the `disallowedTypes` list, this check will report an error
+stop. Otherwise, if the `allowedTypes` list is not empty, the check will report
+an error if the type is not part of the `allowedTypes` list.
+
+### `types`
+
+This check restricts the types that can be used in all contexts. It is
+configured with a lists of allowed and disallowed types.
 
 ```toml
 [checks.types]
-disallowed = [
+disallowedTypes = [
     "union",
 ]
 ```
@@ -235,9 +250,7 @@ See the [full list of available types](#supported-type-names). Types are [matche
 
 ## Supported type names
 
-There are multiple checks which can be configured by specifying the types they act upon. These checks are:
-- [`map.value.restricted`](#mapvaluerestricted)
-- [`types.disallowed`](#typesdisallowed)
+There are multiple checks which can be configured by specifying the types they act upon.
 
 The supported type names include:
 - **Primitives**: `bool`, `i8`, `i16`, `i32`, `i64`, `double`, `string`, `binary`

--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ disallowedTypes = [
 ## Type Checks
 
 Some checks are used to restrict the set of types that are allowed in various
-contexts, with the [`types`][] check acting globally. All of these checks use
-the same matching and configuration pattern.
+contexts, with the [`types`](#types) check acting globally. All of these checks
+use the same matching and configuration pattern.
 
 If the type is in the `disallowedTypes` list, this check will report an error
 stop. Otherwise, if the `allowedTypes` list is not empty, the check will report

--- a/check.go
+++ b/check.go
@@ -224,3 +224,32 @@ func (c *C) ResolveType(ref ast.TypeReference) ast.Node {
 	}
 	return nil
 }
+
+// CheckType checks if a type is allowed.
+//
+// If the type appears in disallowedTypes, it is not allowed.
+// If allowedTypes is not empty, then the type must appear in it.
+func (c *C) CheckType(n ast.Node, allowedTypes, disallowedTypes []ThriftType) (bool, string) {
+	var name = "<node>"
+	if t, ok := n.(ast.Type); ok {
+		name = t.String()
+	}
+
+	for _, matcher := range disallowedTypes {
+		if matcher.Matches(c, n) {
+			return false, matcher.String()
+		}
+	}
+
+	if len(allowedTypes) == 0 {
+		return true, name
+	}
+
+	for _, matcher := range allowedTypes {
+		if matcher.Matches(c, n) {
+			return true, matcher.String()
+		}
+	}
+
+	return false, name
+}

--- a/check.go
+++ b/check.go
@@ -225,11 +225,11 @@ func (c *C) ResolveType(ref ast.TypeReference) ast.Node {
 	return nil
 }
 
-// CheckType checks if a type is allowed.
+// IsTypeAllowed checks if a type is allowed.
 //
 // If the type appears in disallowedTypes, it is not allowed.
 // If allowedTypes is not empty, then the type must appear in it.
-func (c *C) CheckType(n ast.Node, allowedTypes, disallowedTypes []ThriftType) (bool, string) {
+func (c *C) IsTypeAllowed(n ast.Node, allowedTypes, disallowedTypes []ThriftType) (bool, string) {
 	var name = "<node>"
 	if t, ok := n.(ast.Type); ok {
 		name = t.String()

--- a/check_test.go
+++ b/check_test.go
@@ -129,3 +129,29 @@ func TestC(t *testing.T) {
 		t.Errorf("expected %s, got %s", expected, c.Messages)
 	}
 }
+
+func TestCheckType(t *testing.T) {
+	var stringType ThriftType
+	if err := stringType.UnmarshalString("string"); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		t          ast.Type
+		allowed    []ThriftType
+		disallowed []ThriftType
+		ok         bool
+	}{
+		{ast.BaseType{ID: ast.StringTypeID}, []ThriftType{}, []ThriftType{}, true},
+		{ast.BaseType{ID: ast.StringTypeID}, []ThriftType{stringType}, []ThriftType{}, true},
+		{ast.BaseType{ID: ast.StringTypeID}, []ThriftType{}, []ThriftType{stringType}, false},
+		{ast.BaseType{ID: ast.I32TypeID}, []ThriftType{stringType}, []ThriftType{}, false},
+	}
+
+	c := &C{Filename: "test.thrift", Check: "check"}
+	for _, tt := range tests {
+		if ok, name := c.CheckType(tt.t, tt.allowed, tt.disallowed); ok != tt.ok {
+			t.Errorf("%q (allowed: %v, disallowed: %v), expected %v", name, tt.allowed, tt.disallowed, ok)
+		}
+	}
+}

--- a/check_test.go
+++ b/check_test.go
@@ -130,28 +130,33 @@ func TestC(t *testing.T) {
 	}
 }
 
-func TestCheckType(t *testing.T) {
+func TestIsTypeAllowed(t *testing.T) {
 	var stringType ThriftType
 	if err := stringType.UnmarshalString("string"); err != nil {
 		t.Fatal(err)
 	}
 
 	tests := []struct {
-		t          ast.Type
+		n          ast.Node
 		allowed    []ThriftType
 		disallowed []ThriftType
 		ok         bool
+		name       string
 	}{
-		{ast.BaseType{ID: ast.StringTypeID}, []ThriftType{}, []ThriftType{}, true},
-		{ast.BaseType{ID: ast.StringTypeID}, []ThriftType{stringType}, []ThriftType{}, true},
-		{ast.BaseType{ID: ast.StringTypeID}, []ThriftType{}, []ThriftType{stringType}, false},
-		{ast.BaseType{ID: ast.I32TypeID}, []ThriftType{stringType}, []ThriftType{}, false},
+		{ast.BaseType{ID: ast.StringTypeID}, []ThriftType{}, []ThriftType{}, true, "string"},
+		{ast.BaseType{ID: ast.StringTypeID}, []ThriftType{stringType}, []ThriftType{}, true, "string"},
+		{ast.BaseType{ID: ast.StringTypeID}, []ThriftType{}, []ThriftType{stringType}, false, "string"},
+		{ast.BaseType{ID: ast.I32TypeID}, []ThriftType{stringType}, []ThriftType{}, false, "i32"},
+		{&ast.Program{}, []ThriftType{stringType}, []ThriftType{}, false, "<node>"},
 	}
 
 	c := &C{Filename: "test.thrift", Check: "check"}
 	for _, tt := range tests {
-		if ok, name := c.CheckType(tt.t, tt.allowed, tt.disallowed); ok != tt.ok {
+		ok, name := c.IsTypeAllowed(tt.n, tt.allowed, tt.disallowed)
+		if ok != tt.ok {
 			t.Errorf("%q (allowed: %v, disallowed: %v), expected %v", name, tt.allowed, tt.disallowed, ok)
+		} else if name != tt.name {
+			t.Errorf("expected %q, got %q", tt.name, name)
 		}
 	}
 }

--- a/checks/checks_test.go
+++ b/checks/checks_test.go
@@ -55,3 +55,12 @@ func RunTests(t *testing.T, check *thriftcheck.Check, tests []Test) {
 		}
 	}
 }
+
+func ParseType(t *testing.T, name string) (thriftType thriftcheck.ThriftType) {
+	t.Helper()
+
+	if err := thriftType.UnmarshalString(name); err != nil {
+		t.Fatal(err)
+	}
+	return
+}

--- a/checks/checks_test.go
+++ b/checks/checks_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Pinterest
+// Copyright 2025 Pinterest
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/checks/maps.go
+++ b/checks/maps.go
@@ -19,41 +19,22 @@ import (
 	"go.uber.org/thriftrw/ast"
 )
 
-// CheckMapKeyType reports an error if a disallowed map key type is used.
-// A type is disallowed if it either:
-//   - Appears in `disallowedTypes`
-//   - Does not appear in a non-empty `allowedTypes`
+// CheckMapKeyType returns a thriftcheck.Check that checks if a `map<>` key
+// type is allowed.
 func CheckMapKeyType(allowedTypes, disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
 	return thriftcheck.NewCheck("map.key.type", func(c *thriftcheck.C, mt ast.MapType) {
-		for _, matcher := range disallowedTypes {
-			if matcher.Matches(c, mt.KeyType) {
-				c.Errorf(mt, "map key type %q is disallowed", matcher)
-				return
-			}
+		if ok, name := c.CheckType(mt.KeyType, allowedTypes, disallowedTypes); !ok {
+			c.Errorf(mt, "map key type %q is not allowed", name)
 		}
-
-		if len(allowedTypes) == 0 {
-			return
-		}
-		for _, matcher := range allowedTypes {
-			if matcher.Matches(c, mt.KeyType) {
-				return
-			}
-		}
-		c.Errorf(mt, "map key type %q is not in the 'allowed' list", mt.KeyType)
 	})
 }
 
-// CheckMapValueType returns a thriftcheck.Check that ensures map values don't use disallowed types.
-// The disallowedTypes slice allows configurable type disallowances.
-// Common use cases: disallow nested maps, unions, complex collections, etc.
-func CheckMapValueType(disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
-	return thriftcheck.NewCheck("map.value.disallowed", func(c *thriftcheck.C, mt ast.MapType) {
-		for _, matcher := range disallowedTypes {
-			if matcher.Matches(c, mt.ValueType) {
-				c.Errorf(mt, "map value type %s is disallowed", matcher)
-				return
-			}
+// CheckMapKeyType returns a thriftcheck.Check that checks if a `map<>` value
+// type is allowed.
+func CheckMapValueType(allowedTypes, disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
+	return thriftcheck.NewCheck("map.value.type", func(c *thriftcheck.C, mt ast.MapType) {
+		if ok, name := c.CheckType(mt.ValueType, allowedTypes, disallowedTypes); !ok {
+			c.Errorf(mt, "map value type %q is not allowed", name)
 		}
 	})
 }

--- a/checks/maps.go
+++ b/checks/maps.go
@@ -23,7 +23,7 @@ import (
 // type is allowed.
 func CheckMapKeyType(allowedTypes, disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
 	return thriftcheck.NewCheck("map.key.type", func(c *thriftcheck.C, mt ast.MapType) {
-		if ok, name := c.CheckType(mt.KeyType, allowedTypes, disallowedTypes); !ok {
+		if ok, name := c.IsTypeAllowed(mt.KeyType, allowedTypes, disallowedTypes); !ok {
 			c.Errorf(mt, "map key type %q is not allowed", name)
 		}
 	})
@@ -33,7 +33,7 @@ func CheckMapKeyType(allowedTypes, disallowedTypes []thriftcheck.ThriftType) thr
 // type is allowed.
 func CheckMapValueType(allowedTypes, disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
 	return thriftcheck.NewCheck("map.value.type", func(c *thriftcheck.C, mt ast.MapType) {
-		if ok, name := c.CheckType(mt.ValueType, allowedTypes, disallowedTypes); !ok {
+		if ok, name := c.IsTypeAllowed(mt.ValueType, allowedTypes, disallowedTypes); !ok {
 			c.Errorf(mt, "map value type %q is not allowed", name)
 		}
 	})

--- a/checks/sets.go
+++ b/checks/sets.go
@@ -19,22 +19,12 @@ import (
 	"go.uber.org/thriftrw/ast"
 )
 
-// CheckSetValueType returns a thriftcheck.Check that ensures that only primitive
-// types are used for `set<>` values.
-func CheckSetValueType() thriftcheck.Check {
+// CheckSetValueType returns a thriftcheck.Check that checks if a `set<>` value
+// type is allowed.
+func CheckSetValueType(allowedTypes, disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
 	return thriftcheck.NewCheck("set.value.type", func(c *thriftcheck.C, st ast.SetType) {
-		switch t := st.ValueType.(type) {
-		case ast.BaseType:
-			break
-		case ast.TypeReference:
-			switch c.ResolveType(t).(type) {
-			case ast.BaseType, *ast.Enum, *ast.Typedef:
-				break
-			default:
-				c.Errorf(st, "set value must be a primitive type")
-			}
-		default:
-			c.Errorf(st, "set value must be a primitive type")
+		if ok, name := c.CheckType(st.ValueType, allowedTypes, disallowedTypes); !ok {
+			c.Errorf(st, "set value type %q is not allowed", name)
 		}
 	})
 }

--- a/checks/sets.go
+++ b/checks/sets.go
@@ -23,7 +23,7 @@ import (
 // type is allowed.
 func CheckSetValueType(allowedTypes, disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
 	return thriftcheck.NewCheck("set.value.type", func(c *thriftcheck.C, st ast.SetType) {
-		if ok, name := c.CheckType(st.ValueType, allowedTypes, disallowedTypes); !ok {
+		if ok, name := c.IsTypeAllowed(st.ValueType, allowedTypes, disallowedTypes); !ok {
 			c.Errorf(st, "set value type %q is not allowed", name)
 		}
 	})

--- a/checks/sets_test.go
+++ b/checks/sets_test.go
@@ -17,11 +17,15 @@ package checks_test
 import (
 	"testing"
 
+	"github.com/pinterest/thriftcheck"
 	"github.com/pinterest/thriftcheck/checks"
 	"go.uber.org/thriftrw/ast"
 )
 
 func TestCheckSetValueType(t *testing.T) {
+	enumType := ParseType(t, "enum")
+	stringType := ParseType(t, "string")
+
 	tests := []Test{
 		{
 			node: ast.SetType{ValueType: ast.BaseType{ID: ast.StringTypeID}},
@@ -30,14 +34,14 @@ func TestCheckSetValueType(t *testing.T) {
 		{
 			node: ast.SetType{ValueType: ast.SetType{ValueType: ast.BaseType{ID: ast.StringTypeID}}},
 			want: []string{
-				`t.thrift:0:1: error: set value must be a primitive type (set.value.type)`,
+				`t.thrift:0:1: error: set value type "set<string>" is not allowed (set.value.type)`,
 			},
 		},
 		{
 			prog: &ast.Program{},
 			node: ast.SetType{ValueType: ast.TypeReference{Name: "Enum"}},
 			want: []string{
-				`t.thrift:0:1: error: set value must be a primitive type (set.value.type)`,
+				`t.thrift:0:1: error: set value type "Enum" is not allowed (set.value.type)`,
 			},
 		},
 		{
@@ -49,6 +53,6 @@ func TestCheckSetValueType(t *testing.T) {
 		},
 	}
 
-	check := checks.CheckSetValueType()
+	check := checks.CheckSetValueType([]thriftcheck.ThriftType{enumType, stringType}, []thriftcheck.ThriftType{})
 	RunTests(t, &check, tests)
 }

--- a/checks/types.go
+++ b/checks/types.go
@@ -22,7 +22,7 @@ import (
 // CheckTypesDisallowed reports an error if a disallowed type is used.
 func CheckTypes(allowedTypes, disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
 	return thriftcheck.NewCheck("types", func(c *thriftcheck.C, n ast.Node) {
-		if ok, name := c.CheckType(n, allowedTypes, disallowedTypes); !ok {
+		if ok, name := c.IsTypeAllowed(n, allowedTypes, disallowedTypes); !ok {
 			c.Errorf(n, "type %q is not allowed", name)
 		}
 	})

--- a/checks/types.go
+++ b/checks/types.go
@@ -20,13 +20,10 @@ import (
 )
 
 // CheckTypesDisallowed reports an error if a disallowed type is used.
-func CheckTypesDisallowed(disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
-	return thriftcheck.NewCheck("types.disallowed", func(c *thriftcheck.C, n ast.Node) {
-		for _, matcher := range disallowedTypes {
-			if matcher.Matches(c, n) {
-				c.Errorf(n, "type %q is not allowed", matcher)
-				return
-			}
+func CheckTypes(allowedTypes, disallowedTypes []thriftcheck.ThriftType) thriftcheck.Check {
+	return thriftcheck.NewCheck("types", func(c *thriftcheck.C, n ast.Node) {
+		if ok, name := c.CheckType(n, allowedTypes, disallowedTypes); !ok {
+			c.Errorf(n, "type %q is not allowed", name)
 		}
 	})
 }

--- a/checks/types_test.go
+++ b/checks/types_test.go
@@ -23,21 +23,15 @@ import (
 )
 
 func TestCheckTypesDisallowed(t *testing.T) {
-	var unionType thriftcheck.ThriftType
-	if err := unionType.UnmarshalString("union"); err != nil {
-		t.Fatalf("Failed to unmarshall union type: %v", err)
-	}
-	var mapType thriftcheck.ThriftType
-	if err := mapType.UnmarshalString("map"); err != nil {
-		t.Fatalf("Failed to unmarshall map type: %v", err)
-	}
+	unionType := ParseType(t, "union")
+	mapType := ParseType(t, "map")
 
 	// Tests with a single disallowed type (union).
 	tests := []Test{
 		{
 			node: &ast.Struct{Type: ast.UnionType},
 			want: []string{
-				`t.thrift:0:1: error: type "union" is not allowed (types.disallowed)`,
+				`t.thrift:0:1: error: type "union" is not allowed (types)`,
 			},
 		},
 		{
@@ -46,7 +40,7 @@ func TestCheckTypesDisallowed(t *testing.T) {
 			}},
 			node: ast.TypeReference{Name: "MyUnion"},
 			want: []string{
-				`t.thrift:0:1: error: type "union" is not allowed (types.disallowed)`,
+				`t.thrift:0:1: error: type "union" is not allowed (types)`,
 			},
 		},
 		{
@@ -59,7 +53,7 @@ func TestCheckTypesDisallowed(t *testing.T) {
 		},
 	}
 
-	check := checks.CheckTypesDisallowed([]thriftcheck.ThriftType{unionType})
+	check := checks.CheckTypes([]thriftcheck.ThriftType{}, []thriftcheck.ThriftType{unionType})
 	RunTests(t, &check, tests)
 
 	// Tests with multiple disallowed types (union and map).
@@ -67,7 +61,7 @@ func TestCheckTypesDisallowed(t *testing.T) {
 		{
 			node: &ast.Struct{Type: ast.UnionType},
 			want: []string{
-				`t.thrift:0:1: error: type "union" is not allowed (types.disallowed)`,
+				`t.thrift:0:1: error: type "union" is not allowed (types)`,
 			},
 		},
 		{
@@ -75,7 +69,7 @@ func TestCheckTypesDisallowed(t *testing.T) {
 				KeyType:   ast.BaseType{ID: ast.I16TypeID},
 				ValueType: ast.BaseType{ID: ast.StringTypeID}},
 			want: []string{
-				`t.thrift:0:1: error: type "map" is not allowed (types.disallowed)`,
+				`t.thrift:0:1: error: type "map" is not allowed (types)`,
 			},
 		},
 		{
@@ -84,7 +78,7 @@ func TestCheckTypesDisallowed(t *testing.T) {
 		},
 	}
 
-	check = checks.CheckTypesDisallowed([]thriftcheck.ThriftType{unionType, mapType})
+	check = checks.CheckTypes([]thriftcheck.ThriftType{}, []thriftcheck.ThriftType{unionType, mapType})
 	RunTests(t, &check, tests)
 
 	// Tests with no disallowed types.
@@ -110,6 +104,6 @@ func TestCheckTypesDisallowed(t *testing.T) {
 		},
 	}
 
-	check = checks.CheckTypesDisallowed([]thriftcheck.ThriftType{})
+	check = checks.CheckTypes([]thriftcheck.ThriftType{}, []thriftcheck.ThriftType{})
 	RunTests(t, &check, tests)
 }

--- a/cmd/example.toml
+++ b/cmd/example.toml
@@ -27,19 +27,26 @@ error = 1000
 "*" = "(huge|massive).thrift"
 
 [checks.map]
-[checks.map.key.type]
-allowed = []
-disallowed = []
+[checks.map.key]
+allowedTypes = [
+    "string", # Only allow string map keys
+]
 [checks.map.value]
 # Disallow specific types as map values to enforce coding standards
 # Common examples:
 # - ["map"] to disallow nested maps
 # - ["union"] to prevent unions as map values
 # - ["union", "map"] to disallow both
-disallowed = [
+disallowedTypes = [
     "union",  # Disallow unions as map values
     "map",    # Disallow nested maps
     "string", # Disallow string as map values
+]
+
+[checks.set]
+[checks.set.value]
+allowedTypes = [
+    "string", # Only allow string set values
 ]
 
 [checks.names]
@@ -52,4 +59,6 @@ reserved = [
 py = "^idl\\."
 
 [checks.types]
-disallowed = []
+disallowedTypes = [
+    "union",
+]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,14 +76,18 @@ type Config struct {
 
 		Map struct {
 			Key struct {
-				Type struct {
-					Allowed    []thriftcheck.ThriftType `fig:"allowed"`
-					Disallowed []thriftcheck.ThriftType `fig:"disallowed"`
-				}
+				AllowedTypes    []thriftcheck.ThriftType `fig:"allowedTypes"`
+				DisallowedTypes []thriftcheck.ThriftType `fig:"disallowedTypes"`
 			}
 			Value struct {
-				Disallowed []thriftcheck.ThriftType `fig:"disallowed"`
+				AllowedTypes    []thriftcheck.ThriftType `fig:"allowedTypes"`
+				DisallowedTypes []thriftcheck.ThriftType `fig:"disallowedTypes"`
 			}
+		}
+
+		Set struct {
+			AllowedTypes    []thriftcheck.ThriftType `fig:"allowedTypes"`
+			DisallowedTypes []thriftcheck.ThriftType `fig:"disallowedTypes"`
 		}
 
 		Names struct {
@@ -95,7 +99,8 @@ type Config struct {
 		}
 
 		Types struct {
-			Disallowed []thriftcheck.ThriftType `fig:"disallowed"`
+			AllowedTypes    []thriftcheck.ThriftType `fig:"allowedTypes"`
+			DisallowedTypes []thriftcheck.ThriftType `fig:"disallowedTypes"`
 		}
 	}
 }
@@ -242,12 +247,12 @@ func main() {
 		checks.CheckIncludePath(),
 		checks.CheckIncludeRestricted(cfg.Checks.Include.Restricted),
 		checks.CheckInteger64bit(),
-		checks.CheckMapKeyType(cfg.Checks.Map.Key.Type.Allowed, cfg.Checks.Map.Key.Type.Disallowed),
-		checks.CheckMapValueType(cfg.Checks.Map.Value.Disallowed),
+		checks.CheckMapKeyType(cfg.Checks.Map.Key.AllowedTypes, cfg.Checks.Map.Key.DisallowedTypes),
+		checks.CheckMapValueType(cfg.Checks.Map.Value.AllowedTypes, cfg.Checks.Map.Value.DisallowedTypes),
 		checks.CheckNamesReserved(cfg.Checks.Names.Reserved),
 		checks.CheckNamespacePattern(cfg.Checks.Namespace.Patterns),
-		checks.CheckSetValueType(),
-		checks.CheckTypesDisallowed(cfg.Checks.Types.Disallowed),
+		checks.CheckSetValueType(cfg.Checks.Set.AllowedTypes, cfg.Checks.Set.DisallowedTypes),
+		checks.CheckTypes(cfg.Checks.Types.AllowedTypes, cfg.Checks.Types.DisallowedTypes),
 	}
 
 	checks := allChecks


### PR DESCRIPTION
All type-based checks (maps, sets, and "global") now use consistent
logic and configuration keys.

They can be configured with "allowedTypes" and "disallowedTypes" lists.
If the type appears in "disallowedTypes", an error is reported. If the
list "allowedTypes" is not empty, then the type must appear in it, or an
error is reported.

This is a breaking change for some existing checks, but it gives us a
lot more flexibility after a one-time configuration update, so lets roll
with it.