### PR TITLE
Add a "base" type name

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,12 +244,11 @@ If the type is in the `disallowedTypes` list, this check will report an error
 stop. Otherwise, if the `allowedTypes` list is not empty, the check will report
 an error if the type is not part of the `allowedTypes` list.
 
-The supported type names include:
+The supported type names are:
 
-- **Primitives**: `bool`, `i8`, `i16`, `i32`, `i64`, `double`, `string`, `binary`
-- **Enumerations**: `enum`
+- **Base Types**: `base` _(any base type)_, `bool`, `i8`, `i16`, `i32`, `i64`, `double`, `string`, `binary`
 - **Collections**: `map`, `list`, `set`
-- **Structures**: `union`, `struct`, `exception`
+- **Definitions**: `enum`, `union`, `struct`, `exception`
 
 Types are matched semantically, including resolving type definitions, so
 `typedef`s and other indirect type references are properly handled.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ configured with lists of [allowed and disallowed types](#type-checks).
 ```toml
 [checks.set.value]
 allowedTypes = [
-    "string", # Only allow string set values
+    "base", # Only allow sets of base types
 ]
 ```
 

--- a/cmd/example.toml
+++ b/cmd/example.toml
@@ -46,7 +46,7 @@ disallowedTypes = [
 [checks.set]
 [checks.set.value]
 allowedTypes = [
-    "string", # Only allow string set values
+    "base", # Only allow sets of base types
 ]
 
 [checks.names]

--- a/types.go
+++ b/types.go
@@ -54,12 +54,8 @@ func (t ThriftType) String() string {
 }
 
 var typeMatchers = map[string]typeMatcher{
-	// Collection types
-	"map":  func(c *C, n ast.Node) bool { return matchType[ast.MapType](c, n) },
-	"list": func(c *C, n ast.Node) bool { return matchType[ast.ListType](c, n) },
-	"set":  func(c *C, n ast.Node) bool { return matchType[ast.SetType](c, n) },
-
-	// Primitive types
+	// Base types
+	"base":   func(c *C, n ast.Node) bool { _, ok := n.(ast.BaseType); return ok },
 	"bool":   func(c *C, n ast.Node) bool { return matchBaseType(n, ast.BoolTypeID) },
 	"i8":     func(c *C, n ast.Node) bool { return matchBaseType(n, ast.I8TypeID) },
 	"i16":    func(c *C, n ast.Node) bool { return matchBaseType(n, ast.I16TypeID) },
@@ -69,13 +65,16 @@ var typeMatchers = map[string]typeMatcher{
 	"string": func(c *C, n ast.Node) bool { return matchBaseType(n, ast.StringTypeID) },
 	"binary": func(c *C, n ast.Node) bool { return matchBaseType(n, ast.BinaryTypeID) },
 
-	// Structure types
+	// Collections
+	"map":  func(c *C, n ast.Node) bool { return matchType[ast.MapType](c, n) },
+	"list": func(c *C, n ast.Node) bool { return matchType[ast.ListType](c, n) },
+	"set":  func(c *C, n ast.Node) bool { return matchType[ast.SetType](c, n) },
+
+	// Definitions
+	"enum":      func(c *C, n ast.Node) bool { return matchType[*ast.Enum](c, n) },
 	"union":     func(c *C, n ast.Node) bool { return matchStructureType(c, n, ast.UnionType) },
 	"struct":    func(c *C, n ast.Node) bool { return matchStructureType(c, n, ast.StructType) },
 	"exception": func(c *C, n ast.Node) bool { return matchStructureType(c, n, ast.ExceptionType) },
-
-	// Enum types
-	"enum": func(c *C, n ast.Node) bool { return matchType[*ast.Enum](c, n) },
 }
 
 // Match a generic type, resolving any type references.

--- a/types_test.go
+++ b/types_test.go
@@ -46,9 +46,9 @@ func TestParseTypes(t *testing.T) {
 			expectedCount: 3,
 		},
 		{
-			name:          "valid primitive types",
-			input:         []string{"bool", "i32", "string"},
-			expectedCount: 3,
+			name:          "valid base types",
+			input:         []string{"base", "bool", "i32", "string"},
+			expectedCount: 4,
 		},
 		{
 			name:          "valid structure types",
@@ -119,11 +119,12 @@ func TestTypeMatchers_Functionality(t *testing.T) {
 		{"set matches SetType", "set", ast.SetType{}, true},
 		{"map doesn't match ListType", "map", ast.ListType{}, false},
 
-		// Primitive types
+		// Base types
 		{"i32 matches I32", "i32", ast.BaseType{ID: ast.I32TypeID}, true},
 		{"string matches String", "string", ast.BaseType{ID: ast.StringTypeID}, true},
 		{"bool matches Bool", "bool", ast.BaseType{ID: ast.BoolTypeID}, true},
 		{"i32 doesn't match String", "i32", ast.BaseType{ID: ast.StringTypeID}, false},
+		{"base matches any base type", "base", ast.BaseType{ID: ast.StringTypeID}, true},
 
 		// Structure types - Direct *ast.Struct
 		{"union matches direct Union struct", "union", &ast.Struct{Type: ast.UnionType}, true},


### PR DESCRIPTION
This pseudo-type name matches any base type. It's a useful shorthand for a common use case.

Also, refer to these types collectively as "base types" rather than "primitives", which is more inline with Thrift's terminology. Similarly, use the term "definitions" to group enumerations and structures.