### PR TITLE
Fix the [checks.set] examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ This check restricts the types that can be used as `set<>` values. It is
 configured with lists of [allowed and disallowed types](#type-checks).
 
 ```toml
-[checks.set.value]
+[checks.set]
 allowedTypes = [
     "base", # Only allow sets of base types
 ]

--- a/cmd/example.toml
+++ b/cmd/example.toml
@@ -44,7 +44,6 @@ disallowedTypes = [
 ]
 
 [checks.set]
-[checks.set.value]
 allowedTypes = [
     "base", # Only allow sets of base types
 ]


### PR DESCRIPTION
We no longer use a nested 'value' configuration key.