### PR TITLE
Restore map.key.type and set.value.type behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ allowedTypes = [
 ]
 ```
 
+If `allowedTypes` is not explicitly configured, it defaults to `["base"]`.
+
 ### `map.value.type`
 
 This check restricts the types that can be used as `map<>` values. It is
@@ -218,9 +220,11 @@ configured with lists of [allowed and disallowed types](#type-checks).
 ```toml
 [checks.set]
 allowedTypes = [
-    "base", # Only allow sets of base types
+    "string", # Only allow sets of strings
 ]
 ```
+
+If `allowedTypes` is not explicitly configured, it defaults to `["base"]`.
 
 ### `types`
 

--- a/cmd/example.toml
+++ b/cmd/example.toml
@@ -45,7 +45,7 @@ disallowedTypes = [
 
 [checks.set]
 allowedTypes = [
-    "base", # Only allow sets of base types
+    "string", # Only allow sets of strings
 ]
 
 [checks.names]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,7 +76,7 @@ type Config struct {
 
 		Map struct {
 			Key struct {
-				AllowedTypes    []thriftcheck.ThriftType `fig:"allowedTypes"`
+				AllowedTypes    []thriftcheck.ThriftType `fig:"allowedTypes" default:"[base]"`
 				DisallowedTypes []thriftcheck.ThriftType `fig:"disallowedTypes"`
 			}
 			Value struct {
@@ -86,7 +86,7 @@ type Config struct {
 		}
 
 		Set struct {
-			AllowedTypes    []thriftcheck.ThriftType `fig:"allowedTypes"`
+			AllowedTypes    []thriftcheck.ThriftType `fig:"allowedTypes" default:"[base]"`
 			DisallowedTypes []thriftcheck.ThriftType `fig:"disallowedTypes"`
 		}
 


### PR DESCRIPTION
This restores the default (version 1.0) behavior of these checks, before they were configuration driven. When no explicit `allowedTypes` values are configured for these checks, they default to `["base"]`, which results in the original "only primitive (base) types are allowed" behavior.