### PR TITLE
Revise the type matching tests

### DIFF
--- a/types.go
+++ b/types.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"strings"
 
 	"go.uber.org/thriftrw/ast"
 )
@@ -32,12 +31,11 @@ type ThriftType struct {
 }
 
 // UnmarshalString implements fig.StringUnmarshaler for automatic toml parsing.
-func (t *ThriftType) UnmarshalString(v string) error {
-	name := strings.ToLower(v)
+func (t *ThriftType) UnmarshalString(name string) error {
 	matcher, ok := typeMatchers[name]
 	if !ok {
 		validTypes := slices.Sorted(maps.Keys(typeMatchers))
-		return fmt.Errorf("unknown type: %s, valid types are: %v", v, validTypes)
+		return fmt.Errorf("unknown type: %s, valid types are: %v", name, validTypes)
 	}
 
 	t.name = name


### PR DESCRIPTION
This gives us complete test coverage across all of the type matchers for both the positive and negative cases (i.e. a matcher should only match its target type and no others).

This doesn't yet cover the type resolution (ast.TypeReference) code paths. That will come next.