### PR TITLE
filepath.Clean() the include paths

### DIFF
--- a/linter.go
+++ b/linter.go
@@ -47,7 +47,9 @@ func WithLogger(logger *log.Logger) Option {
 // WithIncludes is an Option that adds Thrift include paths to the linter.
 func WithIncludes(includes []string) Option {
 	return func(l *Linter) {
-		l.includes = includes
+		for _, dir := range includes {
+			l.includes = append(l.includes, filepath.Clean(dir))
+		}
 	}
 }
 

--- a/linter_test.go
+++ b/linter_test.go
@@ -33,10 +33,11 @@ func TestWithLogger(t *testing.T) {
 }
 
 func TestWithIncludes(t *testing.T) {
-	includes := []string{"a", "b"}
+	includes := []string{"a", "b/", "../c/..", "/d"}
+	expected := []string{"a", "b", "..", "/d"}
 	linter := NewLinter(Checks{}, WithIncludes(includes))
-	if !reflect.DeepEqual(linter.includes, includes) {
-		t.Errorf("expected includes to be %v, got %v", includes, linter.includes)
+	if !reflect.DeepEqual(linter.includes, expected) {
+		t.Errorf("expected includes to be %v, got %v", expected, linter.includes)
 	}
 }
 


### PR DESCRIPTION
This normalizes the include path strings for use throughout the linter, parser, and checks.

See: https://pkg.go.dev/path/filepath#Clean